### PR TITLE
Fix problem with row access policy doesnt return bytes proccessed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,10 @@ N/A
 - Rework `_dbt_max_partition` logic in dynamic `insert_overwrite` incremental strategy. Make the default logic compatible with `on_schema_change`, and make it possible to disable or reimplement that logic by defining a custom macro `declare_dbt_max_partition` ([#17](https://github.com/dbt-labs/dbt-bigquery/issues/17), [#39](https://github.com/dbt-labs/dbt-bigquery/issues/39), [#41](https://github.com/dbt-labs/dbt-bigquery/pull/41))
 
 ### Fixes
-
 - Reimplement the `unique` test to handle column expressions and naming overlaps ([#33](https://github.com/dbt-labs/dbt-bigquery/issues/33), [#35](https://github.com/dbt-labs/dbt-bigquery/issues/35), [#10](https://github.com/dbt-labs/dbt-bigquery/pull/10))
 - Avoid error in `dbt deps` + `dbt clean` if default project is missing ([#27](https://github.com/dbt-labs/dbt-bigquery/issues/27), [#40](https://github.com/dbt-labs/dbt-bigquery/pull/40))
+- Fix problem with bytes proccessed return None value when the service account used to connect DBT in bigquery had a row policy access.
+[#47](https://github.com/dbt-labs/dbt-bigquery/issues/47)
 
 ### Under the hood
 - Replace `sample_profiles.yml` with `profile_template.yml`, for use with new `dbt init` ([#43](https://github.com/dbt-labs/dbt-bigquery/pull/43))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,14 @@
 N/A
 
 ### Fixes
-N/A
+- Fix problem with bytes proccessed return None value when the service account used to connect DBT in bigquery had a row policy access.
+([#47](https://github.com/dbt-labs/dbt-bigquery/issues/47), [#48](https://github.com/dbt-labs/dbt-bigquery/pull/48))
 
 ### Under the hood
 N/A
 
 ### Contributors
-N/A
+- [@imartynetz](https://github.com/imartynetz) ([#48](https://github.com/dbt-labs/dbt-bigquery/pull/48))
 
 ## dbt-bigquery 1.0.0b2 (October 25, 2021)
 
@@ -21,8 +22,6 @@ N/A
 ### Fixes
 - Reimplement the `unique` test to handle column expressions and naming overlaps ([#33](https://github.com/dbt-labs/dbt-bigquery/issues/33), [#35](https://github.com/dbt-labs/dbt-bigquery/issues/35), [#10](https://github.com/dbt-labs/dbt-bigquery/pull/10))
 - Avoid error in `dbt deps` + `dbt clean` if default project is missing ([#27](https://github.com/dbt-labs/dbt-bigquery/issues/27), [#40](https://github.com/dbt-labs/dbt-bigquery/pull/40))
-- Fix problem with bytes proccessed return None value when the service account used to connect DBT in bigquery had a row policy access.
-[#47](https://github.com/dbt-labs/dbt-bigquery/issues/47)
 
 ### Under the hood
 - Replace `sample_profiles.yml` with `profile_template.yml`, for use with new `dbt init` ([#43](https://github.com/dbt-labs/dbt-bigquery/pull/43))

--- a/dbt/adapters/bigquery/connections.py
+++ b/dbt/adapters/bigquery/connections.py
@@ -380,7 +380,7 @@ class BigQueryConnectionManager(BaseConnectionManager):
             query_table = client.get_table(query_job.destination)
             code = 'CREATE TABLE'
             num_rows = query_table.num_rows
-            bytes_processed = query_job.total_bytes_processed
+            bytes_processed = query_job.total_bytes_processed or 0
             message = '{} ({} rows, {} processed)'.format(
                 code,
                 format_rows_number(num_rows),


### PR DESCRIPTION
resolves #47 

### Description

<!--- Describe the Pull Request here -->
Solution for the bug I found with row policy access

I found the problem and a solution for it.
Because of some security in row access policy, when the user that is include in row access policy run a query with the table, he receive None as how much bytes is proccessed
[https://cloud.google.com/bigquery/docs/best-practices-row-level-security](url)
So with that dbt the `bytes_processed`return None value and break the `abs(bytes_processed)`
### Checklist

- [ x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-bigquery next" section.