### PR TITLE
add new bq job timeout and retry config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Fixes
 - Fix test related to preventing coercion of boolean values (True, False) to numeric values (0, 1) in query results ([#93](https://github.com/dbt-labs/dbt-bigquery/issues/93))
 
+### Contributors
+- [@hui-zheng](https://github.com/hui-zheng)([#50](https://github.com/dbt-labs/dbt-bigquery/pull/50))
+
 ## dbt-bigquery 1.0.0 (December 3, 2021)
 
 ## dbt-bigquery 1.0.0rc2 (November 24, 2021)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## dbt-bigquery 1.1.0 (Release TBD)
+### Features
+- Provide a fine-grained control of the timeout and retry of BigQuery query with four new dbt profile configs: `job_creation_timeout_seconds`, `job_execution_timeout_seconds`, `job_retry_deadline_seconds`, and `job_retries` ([#45](https://github.com/dbt-labs/dbt-bigquery/issues/45), [#50](https://github.com/dbt-labs/dbt-bigquery/pull/50))
 
 ### Fixes
 - Fix test related to preventing coercion of boolean values (True, False) to numeric values (0, 1) in query results ([#93](https://github.com/dbt-labs/dbt-bigquery/issues/93))
@@ -9,7 +11,6 @@
 
 ### Features
 - Add optional `scopes` profile configuration argument to reduce the BigQuery OAuth scopes down to the minimal set needed. ([#23](https://github.com/dbt-labs/dbt-bigquery/issues/23), [#63](https://github.com/dbt-labs/dbt-bigquery/pull/63))
-- Provide a fine-grained control of the timeout and retry of BigQuery query with four new dbt profile configs: `job_creation_timeout_seconds`, `job_execution_timeout_seconds`, `job_retry_deadline_seconds`, and `job_retries` ([#45](https://github.com/dbt-labs/dbt-bigquery/issues/45), [#50](https://github.com/dbt-labs/dbt-bigquery/pull/50))
 
 ### Fixes
 - Don't apply `require_partition_filter` to temporary tables, thereby fixing `insert_overwrite` strategy when partition filter is required ([#64](https://github.com/dbt-labs/dbt-bigquery/issues/64)), ([#65](https://github.com/dbt-labs/dbt-bigquery/pull/65))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## dbt-bigquery 1.0.0 (Release TBD)
-
+- provide a fine-grained control of the timeout and retry of BigQuery query with four new dbt profile configs: `job_creation_timeout_seconds`, `job_execution_timeout_seconds`, `job_retry_deadline_seconds`, and `job_retries`. [#50](https://github.com/dbt-labs/dbt-bigquery/pull/50)
 ## dbt-bigquery 1.0.0rc1 (November 10, 2021)
 
 ### Fixes
@@ -16,6 +16,7 @@
 ### Contributors
 - [@imartynetz](https://github.com/imartynetz) ([#48](https://github.com/dbt-labs/dbt-bigquery/pull/48))
 - [@Kayrnt](https://github.com/Kayrnt) ([#51](https://github.com/dbt-labs/dbt-bigquery/pull/51))
+- [@hui-zheng](https://github.com/hui-zheng)([#50](https://github.com/dbt-labs/dbt-bigquery/pull/50))
 
 ## dbt-bigquery 1.0.0b2 (October 25, 2021)
 

--- a/dbt/adapters/bigquery/connections.py
+++ b/dbt/adapters/bigquery/connections.py
@@ -284,8 +284,6 @@ class BigQueryConnectionManager(BaseConnectionManager):
         return impersonated_credentials.Credentials(
             source_credentials=source_credentials,
             target_principal=profile_credentials.impersonate_service_account,
-            target_scopes=list(cls.SCOPE),
-            lifetime=profile_credentials.job_execution_timeout_seconds,
             target_scopes=list(profile_credentials.scopes),
             lifetime=profile_credentials.job_execution_timeout_seconds,
         )

--- a/dbt/adapters/bigquery/connections.py
+++ b/dbt/adapters/bigquery/connections.py
@@ -120,12 +120,13 @@ class BigQueryCredentials(Credentials):
     )
 
     _ALIASES = {
+        # 'legacy_name': 'current_name'
         'project': 'database',
         'dataset': 'schema',
         'target_project': 'target_database',
         'target_dataset': 'target_schema',
-        'job_retries': 'retries',
-        'job_execution_timeout_seconds': 'timeout_seconds',
+        'retries': 'job_retries',
+        'timeout_seconds': 'job_execution_timeout_seconds',
     }
 
     @property

--- a/dbt/adapters/bigquery/connections.py
+++ b/dbt/adapters/bigquery/connections.py
@@ -118,8 +118,8 @@ class BigQueryCredentials(Credentials):
         'dataset': 'schema',
         'target_project': 'target_database',
         'target_dataset': 'target_schema',
-        'retries': 'job_retries',
-        'timeout_seconds': 'job_execution_timeout_seconds',
+        'job_retries': 'retries',
+        'job_execution_timeout_seconds': 'timeout_seconds',
     }
 
     @property

--- a/dbt/adapters/bigquery/connections.py
+++ b/dbt/adapters/bigquery/connections.py
@@ -391,7 +391,7 @@ class BigQueryConnectionManager(BaseConnectionManager):
         job_execution_timeout = self.get_job_execution_timeout_seconds(conn)
         def fn():
             return self._query_and_results(
-                client, sql, conn, job_params,
+                client, sql, job_params,
                 job_creation_timeout=job_creation_timeout,
                 job_execution_timeout=job_execution_timeout
             )

--- a/dbt/adapters/bigquery/connections.py
+++ b/dbt/adapters/bigquery/connections.py
@@ -392,8 +392,8 @@ class BigQueryConnectionManager(BaseConnectionManager):
         def fn():
             return self._query_and_results(
                 client, sql, conn, job_params,
-                job_execution_timeout=job_execution_timeout,
-                job_creation_timeout=job_creation_timeout
+                job_creation_timeout=job_creation_timeout,
+                job_execution_timeout=job_execution_timeout
             )
 
         query_job, iterator = self._retry_and_handle(msg=sql, conn=conn, fn=fn)
@@ -547,9 +547,9 @@ class BigQueryConnectionManager(BaseConnectionManager):
         self._retry_and_handle(msg='create dataset', conn=conn, fn=fn)
 
     def _query_and_results(
-        self, client, sql, conn, job_params,
-        job_execution_timeout=None, 
-        job_creation_timeout=None
+        self, client, sql, job_params,
+        job_creation_timeout=None,
+        job_execution_timeout=None
     ):
         """Query the client and wait for results."""
         # Cannot reuse job_config if destination is set and ddl is used

--- a/dbt/adapters/bigquery/connections.py
+++ b/dbt/adapters/bigquery/connections.py
@@ -101,7 +101,7 @@ class BigQueryCredentials(Credentials):
     job_retries: Optional[int] = 1
     job_creation_timeout_seconds: Optional[int] = None
     job_execution_timeout_seconds: Optional[int] = 300
-    
+
     # Keyfile json creds
     keyfile: Optional[str] = None
     keyfile_json: Optional[Dict[str, Any]] = None
@@ -390,6 +390,7 @@ class BigQueryConnectionManager(BaseConnectionManager):
 
         job_creation_timeout = self.get_job_creation_timeout_seconds(conn)
         job_execution_timeout = self.get_job_execution_timeout_seconds(conn)
+
         def fn():
             return self._query_and_results(
                 client, sql, job_params,
@@ -556,8 +557,8 @@ class BigQueryConnectionManager(BaseConnectionManager):
         # Cannot reuse job_config if destination is set and ddl is used
         job_config = google.cloud.bigquery.QueryJobConfig(**job_params)
         query_job = client.query(
-            query=sql, 
-            job_config=job_config, 
+            query=sql,
+            job_config=job_config,
             timeout=job_creation_timeout
         )
         iterator = query_job.result(timeout=job_execution_timeout)

--- a/dbt/adapters/bigquery/connections.py
+++ b/dbt/adapters/bigquery/connections.py
@@ -90,13 +90,16 @@ class BigQueryCredentials(Credentials):
     # environment for the project
     database: Optional[str]
     execution_project: Optional[str] = None
-    timeout_seconds: Optional[int] = 300
     location: Optional[str] = None
     priority: Optional[Priority] = None
-    retries: Optional[int] = 1
     maximum_bytes_billed: Optional[int] = None
     impersonate_service_account: Optional[str] = None
 
+    job_retry_deadline_seconds: Optional[int] = None
+    job_retries: Optional[int] = 1
+    job_creation_timeout_seconds: Optional[int] = None
+    job_execution_timeout_seconds: Optional[int] = 300
+    
     # Keyfile json creds
     keyfile: Optional[str] = None
     keyfile_json: Optional[Dict[str, Any]] = None
@@ -113,6 +116,8 @@ class BigQueryCredentials(Credentials):
         'dataset': 'schema',
         'target_project': 'target_database',
         'target_dataset': 'target_schema',
+        'retries': 'job_retries',
+        'timeout_seconds': 'job_execution_timeout_seconds',
     }
 
     @property
@@ -124,8 +129,10 @@ class BigQueryCredentials(Credentials):
         return self.database
 
     def _connection_keys(self):
-        return ('method', 'database', 'schema', 'location', 'priority',
-                'timeout_seconds', 'maximum_bytes_billed')
+        return ('method', 'database', 'schema', 'location', 
+                'priority', 'maximum_bytes_billed'
+                'job_retry_deadline_seconds', 'job_retries',
+                'job_creation_timeout_seconds', 'job_execution_timeout_seconds')
 
     @classmethod
     def __pre_deserialize__(cls, d: Dict[Any, Any]) -> Dict[Any, Any]:
@@ -252,7 +259,7 @@ class BigQueryConnectionManager(BaseConnectionManager):
             source_credentials=source_credentials,
             target_principal=profile_credentials.impersonate_service_account,
             target_scopes=list(cls.SCOPE),
-            lifetime=profile_credentials.timeout_seconds,
+            lifetime=profile_credentials.job_execution_timeout_seconds,
         )
 
     @classmethod
@@ -302,17 +309,24 @@ class BigQueryConnectionManager(BaseConnectionManager):
         return connection
 
     @classmethod
-    def get_timeout(cls, conn):
+    def get_job_execution_timeout_seconds(cls, conn):
         credentials = conn.credentials
-        return credentials.timeout_seconds
+        return credentials.job_execution_timeout_seconds
 
     @classmethod
-    def get_retries(cls, conn) -> int:
+    def get_job_retries(cls, conn) -> int:
         credentials = conn.credentials
-        if credentials.retries is not None:
-            return credentials.retries
-        else:
-            return 1
+        return credentials.job_retries
+
+    @classmethod
+    def get_job_creation_timeout_seconds(cls, conn):
+        credentials = conn.credentials
+        return credentials.job_creation_timeout_seconds
+
+    @classmethod
+    def get_job_retry_deadline_seconds(cls, conn):
+        credentials = conn.credentials
+        return credentials.job_retry_deadline_seconds
 
     @classmethod
     def get_table_from_response(cls, resp):
@@ -347,8 +361,14 @@ class BigQueryConnectionManager(BaseConnectionManager):
         if maximum_bytes_billed is not None and maximum_bytes_billed != 0:
             job_params['maximum_bytes_billed'] = maximum_bytes_billed
 
+        job_creation_timeout = self.get_job_creation_timeout_seconds(conn)
+        job_execution_timeout = self.get_job_execution_timeout_seconds(conn)
         def fn():
-            return self._query_and_results(client, sql, conn, job_params)
+            return self._query_and_results(
+                client, sql, conn, job_params,
+                job_execution_timeout=job_execution_timeout,
+                job_creation_timeout=job_creation_timeout
+            )
 
         query_job, iterator = self._retry_and_handle(msg=sql, conn=conn, fn=fn)
 
@@ -455,7 +475,7 @@ class BigQueryConnectionManager(BaseConnectionManager):
                 write_disposition=write_disposition)
             copy_job = client.copy_table(
                 source_ref_array, destination_ref, job_config=job_config)
-            iterator = copy_job.result(timeout=self.get_timeout(conn))
+            iterator = copy_job.result(timeout=self.get_job_execution_timeout_seconds(conn))
             return copy_job, iterator
 
         self._retry_and_handle(
@@ -504,12 +524,20 @@ class BigQueryConnectionManager(BaseConnectionManager):
             return client.create_dataset(dataset, exists_ok=True)
         self._retry_and_handle(msg='create dataset', conn=conn, fn=fn)
 
-    def _query_and_results(self, client, sql, conn, job_params, timeout=None):
+    def _query_and_results(
+        self, client, sql, conn, job_params,
+        job_execution_timeout=None, 
+        job_creation_timeout=None
+    ):
         """Query the client and wait for results."""
         # Cannot reuse job_config if destination is set and ddl is used
         job_config = google.cloud.bigquery.QueryJobConfig(**job_params)
-        query_job = client.query(sql, job_config=job_config)
-        iterator = query_job.result(timeout=timeout)
+        query_job = client.query(
+            query=sql, 
+            job_config=job_config, 
+            timeout=job_creation_timeout
+        )
+        iterator = query_job.result(timeout=job_execution_timeout)
 
         return query_job, iterator
 
@@ -525,9 +553,9 @@ class BigQueryConnectionManager(BaseConnectionManager):
         with self.exception_handler(msg):
             return retry.retry_target(
                 target=fn,
-                predicate=_ErrorCounter(self.get_retries(conn)).count_error,
+                predicate=_ErrorCounter(self.get_job_retries(conn)).count_error,
                 sleep_generator=self._retry_generator(),
-                deadline=None,
+                deadline=self.get_job_retry_deadline_seconds(conn),
                 on_error=reopen_conn_on_error)
 
     def _retry_generator(self):

--- a/dbt/adapters/bigquery/impl.py
+++ b/dbt/adapters/bigquery/impl.py
@@ -697,7 +697,7 @@ class BigQueryAdapter(BaseAdapter):
             job = client.load_table_from_file(f, table, rewind=True,
                                               job_config=load_config)
 
-        timeout = self.connections.get_timeout(conn)
+        timeout = self.connections.get_job_execution_timeout_seconds(conn)
         with self.connections.exception_handler("LOAD TABLE"):
             self.poll_until_job_completes(job, timeout)
 

--- a/dbt/include/bigquery/profile_template.yml
+++ b/dbt/include/bigquery/profile_template.yml
@@ -1,7 +1,7 @@
 fixed:
   type: bigquery
   priority: interactive
-  fixed_retries: 1
+  job_retries: 1
 prompts:
   _choose_authentication_method:
     oauth:
@@ -17,7 +17,7 @@ prompts:
   threads:
     hint: '1 or more'
     type: 'int'
-  timeout_seconds:
+  job_execution_timeout_seconds:
     default: 300
     type: 'int'
   _choose_location:

--- a/tests/integration/docs_generate_tests/test_docs_generate.py
+++ b/tests/integration/docs_generate_tests/test_docs_generate.py
@@ -1165,7 +1165,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'database': self.default_database,
                     'description': 'My table',
                     'external': None,
-                    'freshness': {'error_after': None, 'warn_after': None, 'filter': None},
+                    'freshness': {'error_after': {'count': None, 'period': None}, 'warn_after': {'count': None, 'period': None}, 'filter': None},
                     'identifier': 'seed',
                     'loaded_at_field': None,
                     'loader': 'a_loader',

--- a/tests/unit/test_bigquery_adapter.py
+++ b/tests/unit/test_bigquery_adapter.py
@@ -600,15 +600,14 @@ class TestBigQueryConnectionManager(unittest.TestCase):
 
     @patch('dbt.adapters.bigquery.impl.google.cloud.bigquery')
     def test_query_and_results(self, mock_bq):
-        self.connections.get_job_execution_timeout_seconds = lambda x: 100.0
-
         self.connections._query_and_results(
-          self.mock_client, 'sql', self.mock_connection,
-          {'description': 'blah'})
+            self.mock_client, 'sql', self.mock_connection, {'job_param_1': 'blah'},
+            job_creation_timeout=15,
+            job_execution_timeout=100)
 
         mock_bq.QueryJobConfig.assert_called_once()
         self.mock_client.query.assert_called_once_with(
-          'sql', job_config=mock_bq.QueryJobConfig())
+            'sql', job_config=mock_bq.QueryJobConfig(), timeout=15)
 
     def test_copy_bq_table_appends(self):
         self._copy_table(

--- a/tests/unit/test_bigquery_adapter.py
+++ b/tests/unit/test_bigquery_adapter.py
@@ -600,7 +600,7 @@ class TestBigQueryConnectionManager(unittest.TestCase):
 
     @patch('dbt.adapters.bigquery.impl.google.cloud.bigquery')
     def test_query_and_results(self, mock_bq):
-        self.connections.get_timeout = lambda x: 100.0
+        self.connections.get_job_execution_timeout_seconds = lambda x: 100.0
 
         self.connections._query_and_results(
           self.mock_client, 'sql', self.mock_connection,

--- a/tests/unit/test_bigquery_adapter.py
+++ b/tests/unit/test_bigquery_adapter.py
@@ -601,13 +601,13 @@ class TestBigQueryConnectionManager(unittest.TestCase):
     @patch('dbt.adapters.bigquery.impl.google.cloud.bigquery')
     def test_query_and_results(self, mock_bq):
         self.connections._query_and_results(
-            self.mock_client, 'sql', self.mock_connection, {'job_param_1': 'blah'},
+            self.mock_client, 'sql', {'job_param_1': 'blah'},
             job_creation_timeout=15,
             job_execution_timeout=100)
 
         mock_bq.QueryJobConfig.assert_called_once()
         self.mock_client.query.assert_called_once_with(
-            'sql', job_config=mock_bq.QueryJobConfig(), timeout=15)
+            query='sql', job_config=mock_bq.QueryJobConfig(), timeout=15)
 
     def test_copy_bq_table_appends(self):
         self._copy_table(

--- a/tests/unit/test_bigquery_adapter.py
+++ b/tests/unit/test_bigquery_adapter.py
@@ -512,6 +512,7 @@ class TestBigQueryConnectionManager(unittest.TestCase):
         credentials = Mock(BigQueryCredentials)
         profile = Mock(query_comment=None, credentials=credentials)
         self.connections = BigQueryConnectionManager(profile=profile)
+
         self.mock_client = Mock(
           dbt.adapters.bigquery.impl.google.cloud.bigquery.Client)
         self.mock_connection = MagicMock()
@@ -519,12 +520,14 @@ class TestBigQueryConnectionManager(unittest.TestCase):
         self.mock_connection.handle = self.mock_client
 
         self.connections.get_thread_connection = lambda: self.mock_connection
+        self.connections.get_job_retry_deadline_seconds = lambda x: None
+        self.connections.get_job_retries = lambda x: 1
 
     @patch(
         'dbt.adapters.bigquery.connections._is_retryable', return_value=True)
     def test_retry_and_handle(self, is_retryable):
         self.connections.DEFAULT_MAXIMUM_DELAY = 2.0
-
+    
         @contextmanager
         def dummy_handler(msg):
             yield
@@ -587,9 +590,9 @@ class TestBigQueryConnectionManager(unittest.TestCase):
         self.assertTrue(_is_retryable(rate_limit_error))
 
     def test_drop_dataset(self):
+
         mock_table = Mock()
         mock_table.reference = 'table1'
-
         self.mock_client.list_tables.return_value = [mock_table]
 
         self.connections.drop_dataset('project', 'dataset')


### PR DESCRIPTION
resolves #45 



### Description

Description
This PR provides a fine-grained control of the timeout and retry to bq query with four dbt-profile configs

```
job_creation_timeout_seconds     # specific for initiate BQ job, to control the timeout of step 1, query()
job_execution_timeout_seconds    # specific for awaiting job result, to control the timeout of step 2, result()

job_retry_deadline_seconds       # to control the overal query, retry_deadline of _query_and_results()
job_retries                      # to control the overall query, retries of _query_and_results()
```


These settings would allow us to control the timeouts of step 1 and step 2 of the BigQuery on their own ( See below), hence maximizing the chances to mitigate different kinds of intermittent errors.

For example, we could set the configs below to fail faster at the step of BQ job creation, while allowing queries with long-running results.
```
job_creation_timeout_seconds=30
job_execution_timeout_seconds=1200
job_retry_deadline_seconds=1500
job_retries=3
```
NOTE:
job_execution_timeout_seconds is the renaming of the previous timeout config.
job_retries is the renaming of the previous retries config.


Context
---

at the core, BigQuery query is made by two steps in dbt

    def _query_and_results(self, client, sql, conn, job_params, timeout=None):
        """Query the client and wait for results."""
        # Cannot reuse job_config if destination is set and ddl is used
        job_config = google.cloud.bigquery.QueryJobConfig(**job_params)    # <--- Step 1
        query_job = client.query(sql, job_config=job_config)               # <--- Step 2
        iterator = query_job.result(timeout=timeout)
        return query_job, iterator
In the first step, client.query() submits a query to BQ JobInsert API server, when succeeded, BQ server creates a new BigQuery query job, and return the query job id back to the client as part ofquery_job object. This step shall be very quick, normally under a few seconds. however, in some rare cases, it would take much longer and might even up to 4 minutes according to the BigQuery engineering team.

In the 2nd step, query_job.result() await for the BigQuery to execute (running) the query and return the results to the client as an iterator. depending on the complexity of the query, this step could takes long, from tens of seconds to tens of minutes.

--- 

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-bigquery next" section.