### PR TITLE
Change Bigquery google-api-core max version dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 N/A
 
 ### Fixes
-N/A
+- Capping `google-api-core` to version `1.31.3` due to `protobuf` dependency conflict ([#53](https://github.com/dbt-labs/dbt-bigquery/pull/53))
 
 ### Under the hood
 N/A

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
         'protobuf>=3.13.0,<4',
         'google-cloud-core>=1.3.0,<2',
         'google-cloud-bigquery>=1.25.0,<3',
-        'google-api-core>=1.16.0,<2',
+        'google-api-core>=1.16.0,<1.31.3',
         'googleapis-common-protos>=1.6.0,<2',
         'six>=1.14.0',
     ],


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-core/issues/4171

### Description

Port of this PR from Core: https://github.com/dbt-labs/dbt-core/pull/4192

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-bigquery next" section.