### PR TITLE
Bump google dependency upper bounds, remove `six`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ N/A
 
 ### Under the hood
 - Capping `google-api-core` to version `1.31.3` due to `protobuf` dependency conflict ([#53](https://github.com/dbt-labs/dbt-bigquery/pull/53))
+- Bump `google-cloud-core` and `google-api-core` upper bounds to `<3`, thereby removing `<1.31.3` limit on the latter. Remove explicit dependency on `six` ([#57](https://github.com/dbt-labs/dbt-bigquery/pull/57))
 
 ### Contributors
 - [@imartynetz](https://github.com/imartynetz) ([#48](https://github.com/dbt-labs/dbt-bigquery/pull/48))

--- a/setup.py
+++ b/setup.py
@@ -75,11 +75,10 @@ setup(
     install_requires=[
         'dbt-core~={}'.format(dbt_core_version),
         'protobuf>=3.13.0,<4',
-        'google-cloud-core>=1.3.0,<2',
+        'google-cloud-core>=1.3.0,<3',
         'google-cloud-bigquery>=1.25.0,<3',
-        'google-api-core>=1.16.0,<1.31.3',
+        'google-api-core>=1.16.0,<3',
         'googleapis-common-protos>=1.6.0,<2',
-        'six>=1.14.0',
     ],
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
Not sure why `dependabot` isn't working for `setup.py` here either. In any case:
- Try bumping google cloud/bigquery/api dependencies to include latest major version
- Remove `six`, which we added way back when to fix a dependency mistake in `dbt-bigquery==1.23.0`; we now require `>=1.25.0` (https://github.com/dbt-labs/dbt-core/pull/2007, https://github.com/googleapis/google-cloud-python/issues/9965). We haven't supported python2 for some time, so I don't see any reason to keep `six` hanging around