### PR TITLE
Slack message for failed nightly runs

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -208,3 +208,19 @@ jobs:
             "You do not have permissions to run integration tests, @dbt-labs/core "\
             "needs to label this PR with `ok to test` in order to run integration tests!"
           check_for_duplicate_msg: true
+
+  slack-results:
+    runs-on: ubuntu-latest
+    needs: test 
+    if: always()
+
+    steps:
+      - name: Posting scheduled run failures
+        uses: ravsamhq/notify-slack-action@v1
+        if: ${{ github.event_name == 'schedule' }}
+        with:
+          notification_title: 'BigQuery nightly integration test failed'
+          status: ${{ job.status }}
+          notify_when: 'failure'
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DEV_CORE_ALERTS }}


### PR DESCRIPTION
### Description

When a scheduled run fails, this will post it to slack

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-bigquery next" section.