### PR TITLE
enrich adapter response for UPDATE and SELECT queries

### DIFF
--- a/dbt/adapters/bigquery/connections.py
+++ b/dbt/adapters/bigquery/connections.py
@@ -417,7 +417,7 @@ class BigQueryConnectionManager(BaseConnectionManager):
             bytes_processed = query_job.total_bytes_processed
             message = f'{code} ({self.format_bytes(bytes_processed)} processed)'
 
-        elif query_job.statement_type in ['INSERT', 'DELETE', 'MERGE']:
+        elif query_job.statement_type in ['INSERT', 'DELETE', 'MERGE', 'UPDATE']:
             code = query_job.statement_type
             num_rows = query_job.num_dml_affected_rows
             num_rows_formated = self.format_rows_number(num_rows)
@@ -425,6 +425,18 @@ class BigQueryConnectionManager(BaseConnectionManager):
             processed_bytes = self.format_bytes(bytes_processed)
             message = f'{code} ({num_rows_formated} rows, {processed_bytes} processed)'
 
+        elif query_job.statement_type == 'SELECT':
+            conn = self.get_thread_connection()
+            client = conn.handle
+            # use anonymous table for num_rows
+            query_table = client.get_table(query_job.destination)
+            code = 'SELECT'
+            num_rows = query_table.num_rows
+            num_rows_formated = self.format_rows_number(num_rows)
+            bytes_processed = query_job.total_bytes_processed
+            processed_bytes = self.format_bytes(bytes_processed)
+            message = f'{code} ({num_rows_formated} rows, {processed_bytes} processed)'
+            
         response = BigQueryAdapterResponse(
             _message=message,
             rows_affected=num_rows,

--- a/dbt/adapters/bigquery/connections.py
+++ b/dbt/adapters/bigquery/connections.py
@@ -436,7 +436,7 @@ class BigQueryConnectionManager(BaseConnectionManager):
             bytes_processed = query_job.total_bytes_processed
             processed_bytes = self.format_bytes(bytes_processed)
             message = f'{code} ({num_rows_formated} rows, {processed_bytes} processed)'
-            
+
         response = BigQueryAdapterResponse(
             _message=message,
             rows_affected=num_rows,


### PR DESCRIPTION
resolves #68 

### Description

Add logic in `BigQueryConnectionManager.execute` to enrich the response with more info for UPDATE and SELECT statements. 

UPDATE responses will match that of other DML operations, while SELECT will return the following:
- `bytes_processed` = total reported bytes processed from running the SELECT statement
- `rows_affected` = number of rows in the query result

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-bigquery next" section.