### PR TITLE
Make sure partition_by is in config if setting require_partition_filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This will prevent BigQuery from throwing an error since non-partitioned tables c
 
 ### Contributors
 - [@hui-zheng](https://github.com/hui-zheng)([#50](https://github.com/dbt-labs/dbt-bigquery/pull/50))
+- [@oliverrmaa](https://github.com/oliverrmaa)([#](https://github.com/dbt-labs/dbt-bigquery/pull/109))
 
 ## dbt-bigquery 1.0.0 (December 3, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 - Fix test related to preventing coercion of boolean values (True, False) to numeric values (0, 1) in query results ([#93](https://github.com/dbt-labs/dbt-bigquery/issues/93))
+- Add a check in `get_table_options` to check that the table has a `partition_by` in the config.
+This will prevent BigQuery from throwing an error since non-partitioned tables cannot have `require_partition_filter` ([#107](https://github.com/dbt-labs/dbt-bigquery/issues/107))
 
 ### Contributors
 - [@hui-zheng](https://github.com/hui-zheng)([#50](https://github.com/dbt-labs/dbt-bigquery/pull/50))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This will prevent BigQuery from throwing an error since non-partitioned tables c
 
 ### Contributors
 - [@hui-zheng](https://github.com/hui-zheng)([#50](https://github.com/dbt-labs/dbt-bigquery/pull/50))
-- [@oliverrmaa](https://github.com/oliverrmaa)([#](https://github.com/dbt-labs/dbt-bigquery/pull/109))
+- [@oliverrmaa](https://github.com/oliverrmaa)([#109](https://github.com/dbt-labs/dbt-bigquery/pull/109))
 
 ## dbt-bigquery 1.0.0 (December 3, 2021)
 

--- a/dbt/adapters/bigquery/impl.py
+++ b/dbt/adapters/bigquery/impl.py
@@ -767,7 +767,7 @@ class BigQueryAdapter(BaseAdapter):
             # It doesn't apply the `require_partition_filter` option for a temporary table
             # so that we avoid the error by not specifying a partition with a temporary table
             # in the incremental model.
-            if config.get('require_partition_filter') is not None:
+            if config.get('require_partition_filter') and config.get('partition_by') is not None:
                 opts['require_partition_filter'] = config.get(
                     'require_partition_filter')
             if config.get('partition_expiration_days') is not None:

--- a/dbt/adapters/bigquery/impl.py
+++ b/dbt/adapters/bigquery/impl.py
@@ -767,7 +767,8 @@ class BigQueryAdapter(BaseAdapter):
             # It doesn't apply the `require_partition_filter` option for a temporary table
             # so that we avoid the error by not specifying a partition with a temporary table
             # in the incremental model.
-            if config.get('require_partition_filter') and config.get('partition_by') is not None:
+            if config.get('require_partition_filter') is not None and \
+                    config.get('partition_by') is not None:
                 opts['require_partition_filter'] = config.get(
                     'require_partition_filter')
             if config.get('partition_expiration_days') is not None:


### PR DESCRIPTION
resolves #107

### Description

This PR adds an additional condition in `get_table_options` for `require_partition_filter`. Essentially, both the `require_partition_filter` and `partition_by` options must both not be none for `require_partition_filter` to work. This way, non-partitioned tables cannot have `require_partition_filter` applied to them.

This should allow users to just put `require_partition_filter` in the dbt_project.yml file instead of needing to make sure they only add it to configs for models that has `partition_by` in it. 

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-bigquery next" section.