### PR TITLE
Simplify usage of BigQuery's TableReference and DatasetReference Clas…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## dbt-bigquery 1.0.2 (Release TBD)
+
+### Under the hood
+- Address BigQuery API deprecation warning and simplify usage of `TableReference` and `DatasetReference` objects ([#97](https://github.com/dbt-labs/dbt-bigquery/issues/97))
+
 ## dbt-bigquery 1.0.0 (December 3, 2021)
 
 ## dbt-bigquery 1.0.0rc2 (November 24, 2021)

--- a/dbt/adapters/bigquery/impl.py
+++ b/dbt/adapters/bigquery/impl.py
@@ -150,12 +150,9 @@ class BigQueryAdapter(BaseAdapter):
             self.cache_dropped(relation)
 
         conn = self.connections.get_thread_connection()
-        client = conn.handle
 
-        dataset = self.connections.dataset(relation.database, relation.schema,
-                                           conn)
-        relation_object = dataset.table(relation.identifier)
-        client.delete_table(relation_object)
+        table_ref = self.get_table_ref_from_relation(relation)
+        conn.handle.delete_table(table_ref)
 
     def truncate_relation(self, relation: BigQueryRelation) -> None:
         raise dbt.exceptions.NotImplementedException(
@@ -169,10 +166,7 @@ class BigQueryAdapter(BaseAdapter):
         conn = self.connections.get_thread_connection()
         client = conn.handle
 
-        from_table_ref = self.connections.table_ref(from_relation.database,
-                                                    from_relation.schema,
-                                                    from_relation.identifier,
-                                                    conn)
+        from_table_ref = self.get_table_ref_from_relation(from_relation)
         from_table = client.get_table(from_table_ref)
         if from_table.table_type == "VIEW" or \
                 from_relation.type == RelationType.View or \
@@ -181,10 +175,7 @@ class BigQueryAdapter(BaseAdapter):
                 'Renaming of views is not currently supported in BigQuery'
             )
 
-        to_table_ref = self.connections.table_ref(to_relation.database,
-                                                  to_relation.schema,
-                                                  to_relation.identifier,
-                                                  conn)
+        to_table_ref = self.get_table_ref_from_relation(to_relation)
 
         self.cache_renamed(from_relation, to_relation)
         client.copy_table(from_table_ref, to_table_ref)
@@ -212,15 +203,13 @@ class BigQueryAdapter(BaseAdapter):
         conn = self.connections.get_thread_connection()
         client = conn.handle
 
-        bigquery_dataset = self.connections.dataset(
-            database, schema, conn
-        )
+        dataset_ref = self.connections.dataset_ref(database, schema)
         # try to do things with the dataset. If it doesn't exist it will 404.
         # we have to do it this way to handle underscore-prefixed datasets,
         # which appear in neither the information_schema.schemata view nor the
         # list_datasets method.
         try:
-            next(iter(client.list_tables(bigquery_dataset, max_results=1)))
+            next(iter(client.list_tables(dataset_ref, max_results=1)))
         except StopIteration:
             pass
         except google.api_core.exceptions.NotFound:
@@ -262,12 +251,12 @@ class BigQueryAdapter(BaseAdapter):
         connection = self.connections.get_thread_connection()
         client = connection.handle
 
-        bigquery_dataset = self.connections.dataset(
-            schema_relation.database, schema_relation.schema, connection
+        dataset_ref = self.connections.dataset_ref(
+            schema_relation.database, schema_relation.schema
         )
 
         all_tables = client.list_tables(
-            bigquery_dataset,
+            dataset_ref,
             # BigQuery paginates tables by alphabetizing them, and using
             # the name of the last table on a page as the key for the
             # next page. If that key table gets dropped before we run
@@ -583,11 +572,10 @@ class BigQueryAdapter(BaseAdapter):
         """
         return PartitionConfig.parse(raw_partition_by)
 
-    def get_table_ref_from_relation(self, conn, relation):
-        return self.connections.table_ref(relation.database,
-                                          relation.schema,
-                                          relation.identifier,
-                                          conn)
+    def get_table_ref_from_relation(self, relation):
+        return self.connections.table_ref(
+            relation.database, relation.schema, relation.identifier
+        )
 
     def _update_column_dict(self, bq_column_dict, dbt_columns, parent=''):
         """
@@ -629,7 +617,7 @@ class BigQueryAdapter(BaseAdapter):
             return
 
         conn = self.connections.get_thread_connection()
-        table_ref = self.get_table_ref_from_relation(conn, relation)
+        table_ref = self.get_table_ref_from_relation(relation)
         table = conn.handle.get_table(table_ref)
 
         new_schema = []
@@ -651,12 +639,7 @@ class BigQueryAdapter(BaseAdapter):
         conn = self.connections.get_thread_connection()
         client = conn.handle
 
-        table_ref = self.connections.table_ref(
-            database,
-            schema,
-            identifier,
-            conn
-        )
+        table_ref = self.connections.table_ref(database, schema, identifier)
         table = client.get_table(table_ref)
         table.description = description
         client.update_table(table, ['description'])
@@ -670,9 +653,7 @@ class BigQueryAdapter(BaseAdapter):
         conn = self.connections.get_thread_connection()
         client = conn.handle
 
-        table_ref = self.connections.table_ref(relation.database,
-                                               relation.schema,
-                                               relation.identifier, conn)
+        table_ref = self.get_table_ref_from_relation(relation)
         table = client.get_table(table_ref)
 
         new_columns = [col.column_to_bq_schema() for col in columns]
@@ -688,14 +669,14 @@ class BigQueryAdapter(BaseAdapter):
         conn = self.connections.get_thread_connection()
         client = conn.handle
 
-        table = self.connections.table_ref(database, schema, table_name, conn)
+        table_ref = self.connections.table_ref(database, schema, table_name)
 
         load_config = google.cloud.bigquery.LoadJobConfig()
         load_config.skip_leading_rows = 1
         load_config.schema = bq_schema
 
         with open(agate_table.original_abspath, "rb") as f:
-            job = client.load_table_from_file(f, table, rewind=True,
+            job = client.load_table_from_file(f, table_ref, rewind=True,
                                               job_config=load_config)
 
         timeout = self.connections.get_timeout(conn)
@@ -793,16 +774,11 @@ class BigQueryAdapter(BaseAdapter):
 
         GrantTarget.validate(grant_target_dict)
         grant_target = GrantTarget.from_dict(grant_target_dict)
-        dataset = client.get_dataset(
-            self.connections.dataset_from_id(grant_target.render())
-        )
+        dataset_ref = self.connections.dataset_ref(grant_target.project, grant_target.dataset)
+        dataset = client.get_dataset(dataset_ref)
 
         if entity_type == 'view':
-            entity = self.connections.table_ref(
-                entity.database,
-                entity.schema,
-                entity.identifier,
-                conn).to_api_repr()
+            entity = self.get_table_ref_from_relation(entity).to_api_repr()
 
         access_entry = AccessEntry(role, entity_type, entity)
         access_entries = dataset.access_entries

--- a/tests/integration/adapter_methods_test/test_adapter_methods.py
+++ b/tests/integration/adapter_methods_test/test_adapter_methods.py
@@ -92,9 +92,10 @@ class TestGrantAccess(DBTIntegrationTest):
         client = conn.handle
 
         grant_target = GrantTarget.from_dict(ae_grant_target_dict)
-        dataset = client.get_dataset(
-            self.adapter.connections.dataset_from_id(grant_target.render())
+        dataset_ref = self.adapter.connections.dataset_ref(
+            grant_target.project, grant_target.dataset
         )
+        dataset = client.get_dataset(dataset_ref)
 
         expected_access_entry = AccessEntry(ae_role, ae_entity_type, ae_entity)
         self.assertTrue(expected_access_entry in dataset.access_entries)

--- a/tests/unit/test_bigquery_adapter.py
+++ b/tests/unit/test_bigquery_adapter.py
@@ -615,8 +615,8 @@ class TestBigQueryConnectionManager(unittest.TestCase):
             write_disposition=dbt.adapters.bigquery.impl.WRITE_APPEND)
         args, kwargs = self.mock_client.copy_table.call_args
         self.mock_client.copy_table.assert_called_once_with(
-            [self._table_ref('project', 'dataset', 'table1', None)],
-            self._table_ref('project', 'dataset', 'table2', None),
+            [self._table_ref('project', 'dataset', 'table1')],
+            self._table_ref('project', 'dataset', 'table2'),
             job_config=ANY)
         args, kwargs = self.mock_client.copy_table.call_args
         self.assertEqual(
@@ -628,8 +628,8 @@ class TestBigQueryConnectionManager(unittest.TestCase):
             write_disposition=dbt.adapters.bigquery.impl.WRITE_TRUNCATE)
         args, kwargs = self.mock_client.copy_table.call_args
         self.mock_client.copy_table.assert_called_once_with(
-            [self._table_ref('project', 'dataset', 'table1', None)],
-            self._table_ref('project', 'dataset', 'table2', None),
+            [self._table_ref('project', 'dataset', 'table1')],
+            self._table_ref('project', 'dataset', 'table2'),
             job_config=ANY)
         args, kwargs = self.mock_client.copy_table.call_args
         self.assertEqual(
@@ -645,12 +645,10 @@ class TestBigQueryConnectionManager(unittest.TestCase):
         labels = self.connections._labels_from_query_comment("not json")
         self.assertEqual(labels, {"query_comment": "not_json"})
 
-    def _table_ref(self, proj, ds, table, conn):
-        return google.cloud.bigquery.table.TableReference.from_string(
-            '{}.{}.{}'.format(proj, ds, table))
+    def _table_ref(self, proj, ds, table):
+        return self.connections.table_ref(proj, ds, table)
 
     def _copy_table(self, write_disposition):
-        self.connections.table_ref = self._table_ref
         source = BigQueryRelation.create(
             database='project', schema='dataset', identifier='table1')
         destination = BigQueryRelation.create(


### PR DESCRIPTION

### Description

Backport of PR #98 changing `dataset` -> `dataset_ref` and `table_ref` as per deprecations from 1.24 we require at least 1.25.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-bigquery next" section.