### PR TITLE
Install dbt-vore@v1.0.1 in `dev_requirements.txt`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,12 @@ This will prevent BigQuery from throwing an error since non-partitioned tables c
 
 ### Under the hood
 - Address BigQuery API deprecation warning and simplify usage of `TableReference` and `DatasetReference` objects ([#97](https://github.com/dbt-labs/dbt-bigquery/issues/97))
+- Specify the version of dbt-core for tests ([#117](https://github.com/dbt-labs/dbt-bigquery/issues/117))
 
 ### Contributors
 - [@hui-zheng](https://github.com/hui-zheng)([#50](https://github.com/dbt-labs/dbt-bigquery/pull/50))
 - [@oliverrmaa](https://github.com/oliverrmaa)([#109](https://github.com/dbt-labs/dbt-bigquery/pull/109))
-- [@yu-iskw](https://github.com/yu-iskw)([#108](https://github.com/dbt-labs/dbt-bigquery/pull/108))
+- [@yu-iskw](https://github.com/yu-iskw)([#108](https://github.com/dbt-labs/dbt-bigquery/pull/108), [#118](https://github.com/dbt-labs/dbt-bigquery/pull/118))
 
 ## dbt-bigquery 1.0.0 (December 3, 2021)
 

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,6 +1,6 @@
 # install latest changes in dbt-core
 # TODO: how to automate switching from develop to version branches?
-git+https://github.com/dbt-labs/dbt.git#egg=dbt-core&subdirectory=core
+git+https://github.com/dbt-labs/dbt.git@v1.0.1#egg=dbt-core&subdirectory=core
 
 bumpversion
 flake8


### PR DESCRIPTION
resolves #117

### Description
We set the version of dbt-core to `v1.0.1` so that we avoid unexpected breaks caused by specification changes of dbt-core.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-bigquery next" section.