### PR TITLE
Bump up to 1.0.3

### DIFF
--- a/dbt/adapters/bigquery/__version__.py
+++ b/dbt/adapters/bigquery/__version__.py
@@ -1,1 +1,1 @@
-version = '1.0.0'
+version = '1.0.1'

--- a/dbt/adapters/bigquery/__version__.py
+++ b/dbt/adapters/bigquery/__version__.py
@@ -1,1 +1,1 @@
-version = '1.0.1'
+version = '1.0.3'


### PR DESCRIPTION
resolves #139

### Description
I would like to bump up to 1.0.1 so that we make it link with dbt-core 1.0.3.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-bigquery next" section.