### PR TITLE
Set job_execution_timeout_seconds default to None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## dbt-bigquery 1.1.0 (TBD)
+## dbt-bigquery 1.1.0 (Release TBD)
+
+### Fixes
+- Restore default behavior for query timeout. Set default `job_execution_timeout` to `None` by default. Keep 300 seconds as query timeout where previously used.
+
+## dbt-bigquery 1.1.0rc1 (April 13, 2022)
 
 ### Under the hood
 - Use dbt.tests.adapter.basic in tests (new test framework) ([#135](https://github.com/dbt-labs/dbt-bigquery/issues/135), [#142](https://github.com/dbt-labs/dbt-bigquery/pull/142))

--- a/dbt/adapters/bigquery/connections.py
+++ b/dbt/adapters/bigquery/connections.py
@@ -103,7 +103,7 @@ class BigQueryCredentials(Credentials):
     job_retry_deadline_seconds: Optional[int] = None
     job_retries: Optional[int] = 1
     job_creation_timeout_seconds: Optional[int] = None
-    job_execution_timeout_seconds: Optional[int] = 300
+    job_execution_timeout_seconds: Optional[int] = None
 
     # Keyfile json creds
     keyfile: Optional[str] = None

--- a/dbt/adapters/bigquery/connections.py
+++ b/dbt/adapters/bigquery/connections.py
@@ -301,7 +301,7 @@ class BigQueryConnectionManager(BaseConnectionManager):
             source_credentials=source_credentials,
             target_principal=profile_credentials.impersonate_service_account,
             target_scopes=list(profile_credentials.scopes),
-            lifetime=profile_credentials.job_execution_timeout_seconds,
+            lifetime=(profile_credentials.job_execution_timeout_seconds or 300),
         )
 
     @classmethod
@@ -524,7 +524,8 @@ class BigQueryConnectionManager(BaseConnectionManager):
         def copy_and_results():
             job_config = google.cloud.bigquery.CopyJobConfig(write_disposition=write_disposition)
             copy_job = client.copy_table(source_ref_array, destination_ref, job_config=job_config)
-            iterator = copy_job.result(timeout=self.get_job_execution_timeout_seconds(conn))
+            timeout = self.get_job_execution_timeout_seconds(conn) or 300
+            iterator = copy_job.result(timeout=timeout)
             return copy_job, iterator
 
         self._retry_and_handle(

--- a/dbt/adapters/bigquery/impl.py
+++ b/dbt/adapters/bigquery/impl.py
@@ -403,7 +403,7 @@ class BigQueryAdapter(BaseAdapter):
 
     @classmethod
     def poll_until_job_completes(cls, job, timeout):
-        retry_count = timeout
+        retry_count = timeout or 300
 
         while retry_count > 0 and job.state != "DONE":
             retry_count -= 1

--- a/dbt/adapters/bigquery/impl.py
+++ b/dbt/adapters/bigquery/impl.py
@@ -403,7 +403,7 @@ class BigQueryAdapter(BaseAdapter):
 
     @classmethod
     def poll_until_job_completes(cls, job, timeout):
-        retry_count = timeout or 300
+        retry_count = timeout
 
         while retry_count > 0 and job.state != "DONE":
             retry_count -= 1
@@ -624,7 +624,7 @@ class BigQueryAdapter(BaseAdapter):
         with open(agate_table.original_abspath, "rb") as f:
             job = client.load_table_from_file(f, table_ref, rewind=True, job_config=load_config)
 
-        timeout = self.connections.get_job_execution_timeout_seconds(conn)
+        timeout = self.connections.get_job_execution_timeout_seconds(conn) or 300
         with self.connections.exception_handler("LOAD TABLE"):
             self.poll_until_job_completes(job, timeout)
 
@@ -647,7 +647,7 @@ class BigQueryAdapter(BaseAdapter):
         with open(local_file_path, "rb") as f:
             job = client.load_table_from_file(f, table_ref, rewind=True, job_config=load_config)
 
-        timeout = self.connections.get_job_execution_timeout_seconds(conn)
+        timeout = self.connections.get_job_execution_timeout_seconds(conn) or 300
         with self.connections.exception_handler("LOAD TABLE"):
             self.poll_until_job_completes(job, timeout)
 


### PR DESCRIPTION
Meta notes:
- resolves #158, which is a likely regression in v1.1.0rc1
- will require backporting to `1.1.latest`, and probably a `1.1.0rc2` release
- will require an update to docs: https://docs.getdbt.com/reference/warehouse-profiles/bigquery-profile#job_execution_timeout_seconds

### Description

This has the effect of passing in `timeout=None` to `query_job.result` by default (rather than 300 seconds). Per [BigQuery's docs](https://googleapis.dev/python/bigquery/latest/generated/google.cloud.bigquery.job.QueryJob.html#google.cloud.bigquery.job.QueryJob.result), this is an optional value, with default `None`:

> The number of seconds to wait for the underlying HTTP transport before using retry. If multiple requests are made under the hood, timeout applies to each individual request.

This restores parity with v1.0 behavior, where we didn't pass a `timeout` into `_query_and_results` for _anything_ except (undocumented) copy jobs. Obviously, if the user-provided value _is_ configured, we'll use it everywhere.

I saw two other places where we were previously using `timeout_seconds` to plumb our own logic:
- the expiration time for service account impersonation
- the polling time for uploading table contents (seeds)

In both cases, I just added back 300 seconds as the fallback value if `job_execution_timeout_seconds` isn't set by the end user. This should also restore parity with default behavior in v1.0, while still allowing end users to configure their own custom timeout.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- ~This PR includes tests, or tests are not required/relevant for this PR~
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-bigquery next" section.
