### PR TITLE
Add oauth target as default for functional tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,9 +7,33 @@ import json
 
 pytest_plugins = ["dbt.tests.fixtures.project"]
 
-# The profile dictionary, used to write out profiles.yml
-@pytest.fixture(scope="class")
-def dbt_profile_target():
+
+def pytest_addoption(parser):
+    parser.addoption("--profile", action="store", default="oauth", type=str)
+
+
+@pytest.fixture(scope="session")
+def dbt_profile_target(request):
+    profile_type = request.config.getoption("--profile")
+    if profile_type == "oauth":
+        target = oauth_target()
+    elif profile_type == "service_account":
+        target = service_account_target()
+    else:
+        raise ValueError(f"Invalid profile type '{profile_type}'")
+    return target
+
+
+def oauth_target():
+    return {
+        'type': 'bigquery',
+        'method': 'oauth',
+        'threads': 1,
+        # project isn't needed if you configure a default, via 'gcloud config set project'
+    }
+
+
+def service_account_target():
     credentials_json_str = os.getenv('BIGQUERY_TEST_SERVICE_ACCOUNT_JSON').replace("'", '')
     credentials = json.loads(credentials_json_str)
     project_id = credentials.get('project_id')

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ skip_install = true
 passenv = DBT_* BIGQUERY_TEST_* PYTEST_ADDOPTS
 commands =
   bigquery: {envpython} -m pytest {posargs} -m profile_bigquery tests/integration
-  bigquery: {envpython} -m pytest {posargs} tests/functional
+  bigquery: {envpython} -m pytest {posargs} tests/functional --profile service_account
 deps =
   -rdev_requirements.txt
   -e.


### PR DESCRIPTION
resolves #151

### Description

Support `oauth` method (i.e. `gcloud` CLI) by default. Much easier to set up than a service account passed (as JSON) to the env var

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- ~This PR includes tests, or tests are not required/relevant for this PR~
- ~I have updated the `CHANGELOG.md` and added information about my change to the "dbt-bigquery next" section.~
