### PR TITLE
Add `slot_ms` to `BigQueryAdapterResponse`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## dbt-bigquery 1.2.0 (Release TBD)
 - Adding Python 3.10 testing and enabling mypy ([#177](https://github.com/dbt-labs/dbt-bigquery/pull/177))
+- Adding `slot_millis` to `BigQueryAdapterResponse` ([#195](https://github.com/dbt-labs/dbt-bigquery/pull/195))
+
+### Contributors
+- [@yu-iskw](https://github.com/yu-iskw)([#195](https://github.com/dbt-labs/dbt-bigquery/pull/195))
 
 ## dbt-bigquery 1.1.0 (April 28, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## dbt-bigquery 1.2.0 (Release TBD)
 - Adding Python 3.10 testing and enabling mypy ([#177](https://github.com/dbt-labs/dbt-bigquery/pull/177))
-- Adding `slot_millis` to `BigQueryAdapterResponse` ([#195](https://github.com/dbt-labs/dbt-bigquery/pull/195))
+- Adding `slot_ms` to `BigQueryAdapterResponse` ([#195](https://github.com/dbt-labs/dbt-bigquery/pull/195))
 
 ### Contributors
 - [@yu-iskw](https://github.com/yu-iskw)([#195](https://github.com/dbt-labs/dbt-bigquery/pull/195))

--- a/dbt/adapters/bigquery/connections.py
+++ b/dbt/adapters/bigquery/connections.py
@@ -86,7 +86,7 @@ class BigQueryConnectionMethod(StrEnum):
 @dataclass
 class BigQueryAdapterResponse(AdapterResponse):
     bytes_processed: Optional[int] = None
-    slot_millis: Optional[int] = None
+    slot_ms: Optional[int] = None
 
 
 @dataclass
@@ -438,6 +438,7 @@ class BigQueryConnectionManager(BaseConnectionManager):
         code = None
         num_rows = None
         bytes_processed = None
+        slot_ms = None
 
         if query_job.statement_type == "CREATE_VIEW":
             code = "CREATE VIEW"
@@ -450,14 +451,14 @@ class BigQueryConnectionManager(BaseConnectionManager):
             num_rows = query_table.num_rows
             num_rows_formated = self.format_rows_number(num_rows)
             bytes_processed = query_job.total_bytes_processed
-            slot_millis = query_job.slot_millis
+            slot_ms = query_job.slot_ms
             processed_bytes = self.format_bytes(bytes_processed)
             message = f"{code} ({num_rows_formated} rows, {processed_bytes} processed)"
 
         elif query_job.statement_type == "SCRIPT":
             code = "SCRIPT"
             bytes_processed = query_job.total_bytes_processed
-            slot_millis = query_job.slot_millis
+            slot_ms = query_job.slot_ms
             message = f"{code} ({self.format_bytes(bytes_processed)} processed)"
 
         elif query_job.statement_type in ["INSERT", "DELETE", "MERGE", "UPDATE"]:
@@ -465,7 +466,7 @@ class BigQueryConnectionManager(BaseConnectionManager):
             num_rows = query_job.num_dml_affected_rows
             num_rows_formated = self.format_rows_number(num_rows)
             bytes_processed = query_job.total_bytes_processed
-            slot_millis = query_job.slot_millis
+            slot_ms = query_job.slot_ms
             processed_bytes = self.format_bytes(bytes_processed)
             message = f"{code} ({num_rows_formated} rows, {processed_bytes} processed)"
 
@@ -478,7 +479,7 @@ class BigQueryConnectionManager(BaseConnectionManager):
             num_rows = query_table.num_rows
             num_rows_formated = self.format_rows_number(num_rows)
             bytes_processed = query_job.total_bytes_processed
-            slot_millis = query_job.slot_millis
+            slot_ms = query_job.slot_ms
             processed_bytes = self.format_bytes(bytes_processed)
             message = f"{code} ({num_rows_formated} rows, {processed_bytes} processed)"
 
@@ -487,7 +488,7 @@ class BigQueryConnectionManager(BaseConnectionManager):
             rows_affected=num_rows,
             code=code,
             bytes_processed=bytes_processed,
-            slot_millis=slot_millis,
+            slot_ms=slot_ms,
         )
 
         return response, table

--- a/dbt/adapters/bigquery/connections.py
+++ b/dbt/adapters/bigquery/connections.py
@@ -86,6 +86,7 @@ class BigQueryConnectionMethod(StrEnum):
 @dataclass
 class BigQueryAdapterResponse(AdapterResponse):
     bytes_processed: Optional[int] = None
+    slot_millis: Optional[int] = None
 
 
 @dataclass
@@ -449,12 +450,14 @@ class BigQueryConnectionManager(BaseConnectionManager):
             num_rows = query_table.num_rows
             num_rows_formated = self.format_rows_number(num_rows)
             bytes_processed = query_job.total_bytes_processed
+            slot_millis = query_job.slot_millis
             processed_bytes = self.format_bytes(bytes_processed)
             message = f"{code} ({num_rows_formated} rows, {processed_bytes} processed)"
 
         elif query_job.statement_type == "SCRIPT":
             code = "SCRIPT"
             bytes_processed = query_job.total_bytes_processed
+            slot_millis = query_job.slot_millis
             message = f"{code} ({self.format_bytes(bytes_processed)} processed)"
 
         elif query_job.statement_type in ["INSERT", "DELETE", "MERGE", "UPDATE"]:
@@ -462,6 +465,7 @@ class BigQueryConnectionManager(BaseConnectionManager):
             num_rows = query_job.num_dml_affected_rows
             num_rows_formated = self.format_rows_number(num_rows)
             bytes_processed = query_job.total_bytes_processed
+            slot_millis = query_job.slot_millis
             processed_bytes = self.format_bytes(bytes_processed)
             message = f"{code} ({num_rows_formated} rows, {processed_bytes} processed)"
 
@@ -474,6 +478,7 @@ class BigQueryConnectionManager(BaseConnectionManager):
             num_rows = query_table.num_rows
             num_rows_formated = self.format_rows_number(num_rows)
             bytes_processed = query_job.total_bytes_processed
+            slot_millis = query_job.slot_millis
             processed_bytes = self.format_bytes(bytes_processed)
             message = f"{code} ({num_rows_formated} rows, {processed_bytes} processed)"
 
@@ -482,6 +487,7 @@ class BigQueryConnectionManager(BaseConnectionManager):
             rows_affected=num_rows,
             code=code,
             bytes_processed=bytes_processed,
+            slot_millis=slot_millis,
         )
 
         return response, table


### PR DESCRIPTION
resolves #194 

### Description
- I am adding `slot_millis` to `BigQueryAdapterResponse` to enable users, specifically with the BigQuery flat fare plan, to analyze consumed slot milliseconds.

### Tests
I tested the implementation with the jaffle_shop project. The subsequent code block is a part of `run_results.json`. We can see `slot_millis` in the `adapter_response` property.

Aside from that, I noticed adapter responses of run results of dbt tests are always `{}`. There might be worthwhile putting responses in it.

```json
  {
    "status": "success",
    "timing": [
      {
        "name": "compile",
        "started_at": "2022-05-31T08:56:50.520946Z",
        "completed_at": "2022-05-31T08:56:50.556098Z"
      },
      {
        "name": "execute",
        "started_at": "2022-05-31T08:56:50.563067Z",
        "completed_at": "2022-05-31T08:56:52.861520Z"
      }
    ],
    "thread_id": "Thread-4",
    "execution_time": 2.343569040298462,
    "adapter_response": {
      "_message": "CREATE TABLE (99.0 rows, 3.2 KB processed)",
      "code": "CREATE TABLE",
      "rows_affected": 99,
      "bytes_processed": 3254,
      "slot_millis": 1667
    },
    "message": "CREATE TABLE (99.0 rows, 3.2 KB processed)",
    "failures": null,
    "unique_id": "model.jaffle_shop.order_payments"
  },
```

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-bigquery next" section.
