### PR TITLE
Env vars for grantees for testing

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -168,9 +168,9 @@ jobs:
           BIGQUERY_TEST_SERVICE_ACCOUNT_JSON: ${{ secrets.BIGQUERY_TEST_SERVICE_ACCOUNT_JSON }}
           BIGQUERY_TEST_ALT_DATABASE: ${{ secrets.BIGQUERY_TEST_ALT_DATABASE }}
           BIGQUERY_TEST_NO_ACCESS_DATABASE: ${{ secrets.BIGQUERY_TEST_NO_ACCESS_DATABASE }}
-          DBT_TEST_USER_1: dbt_test_user_1
-          DBT_TEST_USER_2: dbt_test_user_2
-          DBT_TEST_USER_3: dbt_test_user_3
+          DBT_TEST_USER_1: user:buildbot@dbtlabs.com
+          DBT_TEST_USER_2: user:buildbot@fishtownanalytics.com
+          DBT_TEST_USER_3: group:dev-core@dbtlabs.com
         run: tox
 
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -168,6 +168,9 @@ jobs:
           BIGQUERY_TEST_SERVICE_ACCOUNT_JSON: ${{ secrets.BIGQUERY_TEST_SERVICE_ACCOUNT_JSON }}
           BIGQUERY_TEST_ALT_DATABASE: ${{ secrets.BIGQUERY_TEST_ALT_DATABASE }}
           BIGQUERY_TEST_NO_ACCESS_DATABASE: ${{ secrets.BIGQUERY_TEST_NO_ACCESS_DATABASE }}
+          DBT_TEST_USER_1: dbt_test_user_1
+          DBT_TEST_USER_2: dbt_test_user_2
+          DBT_TEST_USER_3: dbt_test_user_3
         run: tox
 
       - uses: actions/upload-artifact@v2


### PR DESCRIPTION
resolves #215

### Description

Adding these environment variables to the GitHub Actions configuration in the default branch (currently `main`), so they they can be used with subsequent pull requests.

If these aren't configured in the default branch, then they won't be available for PRs.

### Checklist

- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-bigquery next" section.
