### PR TITLE
Multiple options for rendering sql for grants and revokes

### DIFF
--- a/dbt/include/bigquery/macros/adapters/apply_grants.sql
+++ b/dbt/include/bigquery/macros/adapters/apply_grants.sql
@@ -21,6 +21,16 @@
 {%- endmacro -%}
 
 
+{%- macro bigquery__get_grant_sql__option_X(relation, privilege, grantee) -%}
+    grant {{ privilege }} on {{ relation }} to {{ grantees | join(', ') }}
+{%- endmacro -%}
+
+
+{%- macro bigquery__get_revoke_sql__option_X(relation, privilege, grantee) -%}
+    revoke {{ privilege }} on {{ relation }} from {{ grantees | join(', ') }}
+{%- endmacro -%}
+
+
 {%- macro bigquery__get_grant_sql__option_0(relation, privilege, grantee) -%}
     grant `{{ privilege }}` on {{ relation.type }} {{ relation }} to {{ '\"' + grantee|join('\", \"') + '\"' }}
 {%- endmacro -%}

--- a/dbt/include/bigquery/macros/adapters/apply_grants.sql
+++ b/dbt/include/bigquery/macros/adapters/apply_grants.sql
@@ -11,10 +11,76 @@
 {% endmacro %}
 
 
-{%- macro bigquery__get_grant_sql(relation, privilege, grantee) -%}
+{%- macro bigquery__get_grant_sql(relation, privilege, grantees) -%}
+    {{ bigquery__get_grant_sql__option_3(relation, privilege, grantees) }}
+{%- endmacro -%}
+
+
+{%- macro bigquery__get_revoke_sql(relation, privilege, grantees) -%}
+    {{ bigquery__get_revoke_sql__option_3(relation, privilege, grantees) }}
+{%- endmacro -%}
+
+
+{%- macro bigquery__get_grant_sql__option_0(relation, privilege, grantee) -%}
     grant `{{ privilege }}` on {{ relation.type }} {{ relation }} to {{ '\"' + grantee|join('\", \"') + '\"' }}
 {%- endmacro -%}
 
-{%- macro bigquery__get_revoke_sql(relation, privilege, grantee) -%}
+
+{%- macro bigquery__get_revoke_sql__option_0(relation, privilege, grantee) -%}
     revoke `{{ privilege }}` on {{ relation.type }} {{ relation }} from {{ '\"' + grantee|join('\", \"') + '\"' }}
+{%- endmacro -%}
+
+
+{%- macro bigquery__get_grant_sql__option_1(relation, privilege, grantees) -%}
+    grant {{ adapter.quote(privilege) }} on {{ relation.type }} {{ relation }} to {{ string_literal_csv(grantees) }}
+{%- endmacro -%}
+
+
+{%- macro bigquery__get_revoke_sql__option_1(relation, privilege, grantees) -%}
+    revoke {{ adapter.quote(privilege) }} on {{ relation.type }} {{ relation }} from {{ string_literal_csv(grantees) }}
+{%- endmacro -%}
+
+
+{%- macro string_literal_csv(items) -%}
+    {%- for item in items -%}
+        {{ string_literal(item) }}{% if not loop.last %}, {% endif %}
+    {% endfor %}
+{%- endmacro -%}
+
+
+{%- macro bigquery__get_grant_sql__option_2(relation, privilege, grantees) -%}
+    grant {{ adapter.quote(privilege) }} on {{ relation.type }} {{ relation }} to {{ apply_string_literal(grantees) | join(', ') }}
+{%- endmacro -%}
+
+
+{%- macro bigquery__get_revoke_sql__option_2(relation, privilege, grantees) -%}
+    revoke {{ adapter.quote(privilege) }} on {{ relation.type }} {{ relation }} from {{ apply_string_literal(grantees) | join(', ') }}
+{%- endmacro -%}
+
+
+{%- macro apply_string_literal(items) -%}
+    {%- set apply_items = [] -%}
+    {%- for item in items -%}
+        {{ apply_items.append(string_literal(item)) }}
+    {% endfor %}
+    {%- do return(apply_items) -%}
+{%- endmacro -%}
+
+
+{%- macro bigquery__get_grant_sql__option_3(relation, privilege, grantees) -%}
+    grant {{ adapter.quote(privilege) }} on {{ relation.type }} {{ relation }} to {{ apply(string_literal, grantees) | join(', ') }}
+{%- endmacro -%}
+
+
+{%- macro bigquery__get_revoke_sql__option_3(relation, privilege, grantees) -%}
+    revoke {{ adapter.quote(privilege) }} on {{ relation.type }} {{ relation }} from {{ apply(string_literal, grantees) | join(', ') }}
+{%- endmacro -%}
+
+
+{%- macro apply(macro, items) -%}
+    {%- set apply_items = [] -%}
+    {%- for item in items -%}
+        {{ apply_items.append(macro(item)) }}
+    {% endfor %}
+    {%- do return(apply_items) -%}
 {%- endmacro -%}


### PR DESCRIPTION
### For reviewers
Could you give this description and the code a read and provide feedback of which of the options you prefer?

"Keep the implementation as-is" is Option 0 😄 

### Description

This is a refactor to give three separate things:
1. Align with base method signature: plural `grantees` rather than singular `grantee`
1. Use built-in `adapter.quote` method (rather than hard-coded backticks)
1. Use built-in `string_literal` method (rather than hard-coded double quotes)

There are three options (in addition to the original option), all of which are generalized via a helper macro:
1. Option 1: Create comma-separated values from a list 
1. Option 2: Hard-coded application of `string_literal` to a list 
1. Option 3: Application of a variable macro to a list 

### Pros of options
Using built-in methods can provide the following:
- makes implementations more similar to each other, even when there are adapter-specific customizations
- encourages standard style, which enhances readability
- encourage defaulting to usage of the built-in methods (even when they aren't strictly necessary)
- easier to see do a string search for places where quoting is being applied (without extraneous results)
- easier to copy-n-paste snippets into new adapters

### Cons of options
All of these options:
- include an additional helper method, which increases the amount of code

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-bigquery next" section.
