### PR TITLE
Use same auth for Dataproc + GCS

### DIFF
--- a/dbt/adapters/bigquery/connections.py
+++ b/dbt/adapters/bigquery/connections.py
@@ -270,7 +270,7 @@ class BigQueryConnectionManager(BaseConnectionManager):
         return f"{rows_number:3.1f}{unit}".strip()
 
     @classmethod
-    def get_bigquery_credentials(cls, profile_credentials):
+    def get_google_credentials(cls, profile_credentials) -> GoogleCredentials:
         method = profile_credentials.method
         creds = GoogleServiceAccountCredentials.Credentials
 
@@ -300,8 +300,8 @@ class BigQueryConnectionManager(BaseConnectionManager):
         raise FailedToConnectException(error)
 
     @classmethod
-    def get_impersonated_bigquery_credentials(cls, profile_credentials):
-        source_credentials = cls.get_bigquery_credentials(profile_credentials)
+    def get_impersonated_credentials(cls, profile_credentials):
+        source_credentials = cls.get_google_credentials(profile_credentials)
         return impersonated_credentials.Credentials(
             source_credentials=source_credentials,
             target_principal=profile_credentials.impersonate_service_account,
@@ -310,11 +310,15 @@ class BigQueryConnectionManager(BaseConnectionManager):
         )
 
     @classmethod
-    def get_bigquery_client(cls, profile_credentials):
+    def get_credentials(cls, profile_credentials):
         if profile_credentials.impersonate_service_account:
-            creds = cls.get_impersonated_bigquery_credentials(profile_credentials)
+            return cls.get_impersonated_credentials(profile_credentials)
         else:
-            creds = cls.get_bigquery_credentials(profile_credentials)
+            return cls.get_google_credentials(profile_credentials)
+
+    @classmethod
+    def get_bigquery_client(cls, profile_credentials):
+        creds = cls.get_credentials(profile_credentials)
         execution_project = profile_credentials.execution_project
         location = getattr(profile_credentials, "location", None)
 

--- a/dbt/adapters/bigquery/impl.py
+++ b/dbt/adapters/bigquery/impl.py
@@ -832,16 +832,16 @@ class BigQueryAdapter(BaseAdapter):
         for required_config in python_required_configs:
             if not getattr(self.connections.profile.credentials, required_config):
                 raise ValueError(f"Need to supply {required_config} in profile to submit python job")
-
-        dataproc = DataProcHelper(self.connections.profile.credentials)
+        if not hasattr(self, 'dataproc_helper'):
+            self.dataproc_helper = DataProcHelper(self.connections.profile.credentials)
         model_file_name = f"{schema}/{identifier}.py"
         #upload python file to GCS
-        dataproc.upload_to_gcs(
+        self.dataproc_helper.upload_to_gcs(
             model_file_name,
             compiled_code
         )
         # submit dataproc job
-        dataproc.submit_dataproc_job(model_file_name)
+        self.dataproc_helper.submit_dataproc_job(model_file_name)
 
         # TODO proper result for this
         message = "OK"
@@ -864,10 +864,14 @@ class DataProcHelper:
         """
         self.credential = credential
         self.GoogleCredentials = BigQueryConnectionManager.get_credentials(credential)
+        self.storage_client = storage.Client(project=self.credential.database, credentials=self.GoogleCredentials)
+        self.job_client = dataproc_v1.JobControllerClient(
+            client_options={"api_endpoint": "{}-dataproc.googleapis.com:443".format(self.credential.dataproc_region)},
+            credentials=self.GoogleCredentials
+        )
 
     def upload_to_gcs(self, filename: str, compiled_code:str):
-        client = storage.Client(project=self.credential.database, credentials=self.GoogleCredentials)
-        bucket = client.get_bucket(self.credential.gcs_bucket)
+        bucket = self.storage_client.get_bucket(self.credential.gcs_bucket)
         blob = bucket.blob(filename)
         blob.upload_from_string(compiled_code)
 
@@ -881,17 +885,19 @@ class DataProcHelper:
             "placement": {"cluster_name": self.credential.dataproc_cluster_name},
             "pyspark_job": {"main_python_file_uri": "gs://{}/{}".format(self.credential.gcs_bucket, filename)},
         }
-        operation = job_client.submit_job_as_operation(
+        operation = self.job_client.submit_job_as_operation(
             request={"project_id": self.credential.database, "region": self.credential.dataproc_region, "job": job}
         )
         response = operation.result()
+
+        # TODO: there might be useful results here that we can parse and return
         # Dataproc job output is saved to the Cloud Storage bucket
         # allocated to the job. Use regex to obtain the bucket and blob info.
-        matches = re.match("gs://(.*?)/(.*)", response.driver_output_resource_uri)
-        output = (
-            storage.Client()
-            .get_bucket(matches.group(1))
-            .blob(f"{matches.group(2)}.000000000")
-            .download_as_string()
-        )
+        # matches = re.match("gs://(.*?)/(.*)", response.driver_output_resource_uri)
+        # output = (
+        #     self.storage_client
+        #     .get_bucket(matches.group(1))
+        #     .blob(f"{matches.group(2)}.000000000")
+        #     .download_as_string()
+        # )
 


### PR DESCRIPTION
resolves CT-861 (just opened)

Try using the same authentication methods for Dataproc + GCS that we're using for BigQuery, so we don't need to rely on the `GOOGLE_APPLICATION_CREDENTIALS` env var being set.

I still haven't been able to get this running on my local machine, unfortunately. `job_client.submit_job_as_operation` returns:
```
501 Received http2 header with status: 404
```