### PR TITLE
add google requirements to dev-requirements.txt

### DIFF
--- a/dbt/adapters/bigquery/column.py
+++ b/dbt/adapters/bigquery/column.py
@@ -124,4 +124,4 @@ class BigQueryColumn(Column):
             fields = [field.column_to_bq_schema() for field in self.fields]  # type: ignore[attr-defined]
             kwargs = {"fields": fields}
 
-        return SchemaField(self.name, self.dtype, self.mode, **kwargs)
+        return SchemaField(self.name, self.dtype, self.mode, **kwargs)  # type: ignore[arg-type]

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,6 +8,8 @@ bumpversion
 flake8
 flaky
 freezegun==1.1.0
+google-auth
+google-cloud-bigquery
 ipdb
 mypy==0.942
 pip-tools


### PR DESCRIPTION
these two packages were required for me to run unit tests. they should be in `dev-requirements.txt`

reviewers: please make a new virtual environment, run `pip install -r dev-requirements.txt && python -m pytest tests/unit` and make sure the tests run and pass.

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-bigquery next" section.
