### PR TITLE
[CT-1059] Support the location option to create schema

### DIFF
--- a/.changes/unreleased/Features-20220819-214140.yaml
+++ b/.changes/unreleased/Features-20220819-214140.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: Support the `location` option to create schema
+time: 2022-08-19T21:41:40.073268+09:00
+custom:
+  Author: yu-iskw
+  Issue: "273"
+  PR: "275"

--- a/dbt/adapters/bigquery/impl.py
+++ b/dbt/adapters/bigquery/impl.py
@@ -114,6 +114,7 @@ class BigqueryConfig(AdapterConfig):
     require_partition_filter: Optional[bool] = None
     partition_expiration_days: Optional[int] = None
     merge_update_columns: Optional[str] = None
+    location: Optional[str] = None
 
 
 class BigQueryAdapter(BaseAdapter):
@@ -745,6 +746,9 @@ class BigQueryAdapter(BaseAdapter):
                 opts["require_partition_filter"] = config.get("require_partition_filter")
             if config.get("partition_expiration_days") is not None:
                 opts["partition_expiration_days"] = config.get("partition_expiration_days")
+
+        if config.get("location") is not None:
+            opts["location"] = config.get("location")
 
         return opts
 

--- a/tests/unit/test_bigquery_adapter.py
+++ b/tests/unit/test_bigquery_adapter.py
@@ -886,6 +886,15 @@ class TestBigQueryAdapter(BaseTestBigQueryAdapter):
         actual = adapter.get_view_options(mock_config, node={})
         self.assertEqual(expected, actual)
 
+    def test_location(self):
+        adapter = self.get_adapter('oauth')
+        mock_config = create_autospec(
+            RuntimeConfigObject)
+        config = {'location': 'EU'}
+        mock_config.get.side_effect = lambda name: config.get(name)
+        expected = {'location': 'EU'}
+        actual = adapter.get_table_options(mock_config, node={})
+        self.assertEqual(expected, actual)
 
 
 class TestBigQueryFilterCatalog(unittest.TestCase):

--- a/tests/unit/test_bigquery_adapter.py
+++ b/tests/unit/test_bigquery_adapter.py
@@ -893,7 +893,7 @@ class TestBigQueryAdapter(BaseTestBigQueryAdapter):
         config = {'location': 'EU'}
         mock_config.get.side_effect = lambda name: config.get(name)
         expected = {'location': 'EU'}
-        actual = adapter.get_table_options(mock_config, node={})
+        actual = adapter.get_table_options(mock_config, node={}, temporary=False)
         self.assertEqual(expected, actual)
 
 


### PR DESCRIPTION
resolves #273

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->

### Description
Support the location options when creating a dataset

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
