### PR TITLE
Convert df to Spark DataFrame if it is a pandas or pandas-on-Spark DataFrame before writing

### DIFF
--- a/.changes/unreleased/Under the Hood-20220920-151057.yaml
+++ b/.changes/unreleased/Under the Hood-20220920-151057.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Enable pandas-on-Spark DataFrames for dbt python models
+time: 2022-09-20T15:10:57.712169-06:00
+custom:
+  Author: dbeatty10
+  Issue: "316"
+  PR: "317"

--- a/dbt/include/bigquery/macros/materializations/table.sql
+++ b/dbt/include/bigquery/macros/materializations/table.sql
@@ -63,14 +63,37 @@ df = model(dbt, spark)
 # COMMAND ----------
 # this is materialization code dbt generated, please do not modify
 
-# make sure pandas exists
 import importlib.util
-package_name = 'pandas'
-if importlib.util.find_spec(package_name):
-    import pandas
-    if isinstance(df, pandas.core.frame.DataFrame):
-      # convert to pyspark.DataFrame
-      df = spark.createDataFrame(df)
+
+pandas_available = False
+pyspark_available = False
+
+# make sure pandas exists before using it
+if importlib.util.find_spec("pandas"):
+  import pandas
+  pandas_available = True
+
+# make sure pyspark.pandas exists before using it
+if importlib.util.find_spec("pyspark.pandas"):
+  import pyspark.pandas
+  pyspark_available = True
+
+# preferentially convert pandas DataFrames to pandas-on-Spark DataFrames first
+# since they know how to convert pandas DataFrames better than `spark.createDataFrame(df)`
+# and converting from pandas-on-Spark to Spark DataFrame has no overhead
+if pyspark_available and pandas_available and isinstance(df, pandas.core.frame.DataFrame):
+  df = pyspark.pandas.frame.DataFrame(df)
+
+# convert to pyspark.sql.dataframe.DataFrame
+if isinstance(df, pyspark.sql.dataframe.DataFrame):
+  pass  # since it is already a Spark DataFrame
+elif pyspark_available and isinstance(df, pyspark.pandas.frame.DataFrame):
+  df = df.to_spark()
+elif pandas_available and isinstance(df, pandas.core.frame.DataFrame):
+  df = spark.createDataFrame(df)
+else:
+  msg = f"{type(df)} is not a supported type for dbt Python materialization"
+  raise Exception(msg)
 
 df.write \
   .mode("overwrite") \


### PR DESCRIPTION
resolves #316

### Description

Enable pandas and pandas-on-Spark DataFrames for dbt Python models. Convert either of those types to Spark DataFrame before writing.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
