### PR TITLE
fix args for console link logging

### DIFF
--- a/.changes/unreleased/Fixes-20221026-192327.yaml
+++ b/.changes/unreleased/Fixes-20221026-192327.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: fix args for console link logging
+time: 2022-10-26T19:23:27.916326+02:00
+custom:
+  Author: Kayrnt
+  Issue: "362"
+  PR: "363"

--- a/dbt/adapters/bigquery/connections.py
+++ b/dbt/adapters/bigquery/connections.py
@@ -502,7 +502,7 @@ class BigQueryConnectionManager(BaseConnectionManager):
             message = f"{code}"
 
         if location is not None and job_id is not None and project_id is not None:
-            logger.debug(self._bq_job_link(job_id, project_id, location))
+            logger.debug(self._bq_job_link(location, project_id, job_id))
 
         response = BigQueryAdapterResponse(  # type: ignore[call-arg]
             _message=message,


### PR DESCRIPTION
Resolves #362

fix args for console link logging, the params order were wrong on that invocation resulting in an incorrect link
Here the prototype of the function:
https://github.com/dbt-labs/dbt-bigquery/blob/4b22e68f8dd60ea6f21042f158b42adeb32d8a00/dbt/adapters/bigquery/connections.py#L521

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
