### PR TITLE
Add aliasing method for pseudo columns

### DIFF
--- a/dbt/adapters/bigquery/impl.py
+++ b/dbt/adapters/bigquery/impl.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Any, Set, Union, Type
 from dbt.dataclass_schema import dbtClassMixin, ValidationError
-copy_partitions: bool = False
 
 import dbt.deprecations
 import dbt.exceptions

--- a/dbt/adapters/bigquery/impl.py
+++ b/dbt/adapters/bigquery/impl.py
@@ -544,7 +544,7 @@ class BigQueryAdapter(BaseAdapter):
                 conf_partition.field
                 if not conf_partition.time_ingestion_partitioning
                 else "_PARTITIONTIME"
-            )            
+            )
             return (
                 table_field == conf_table_field.lower()
                 and table_granularity == conf_partition.granularity.lower()

--- a/dbt/adapters/bigquery/impl.py
+++ b/dbt/adapters/bigquery/impl.py
@@ -67,6 +67,7 @@ class PartitionConfig(dbtClassMixin):
     granularity: str = "day"
     range: Optional[Dict[str, Any]] = None
     time_ingestion_partitioning: bool = False
+    copy_partitions: bool = False
 
     def reject_partition_field_column(self, columns: List[Any]) -> List[str]:
         return [c for c in columns if not c.name.upper() == self.field.upper()]

--- a/dbt/adapters/bigquery/impl.py
+++ b/dbt/adapters/bigquery/impl.py
@@ -248,8 +248,8 @@ class BigQueryAdapter(BaseAdapter):
             return []
 
     @available
-    def reformat_column_name(self, column) -> str:
-        "Rename pseudo columns to remove leading underscore"
+    def alias_column_name(self, column) -> str:
+        "Alias pseudo columns to remove leading underscore"
         if column[0] == '_':
             column_alias = column.replace('_','',1)
             column = column + f' as {column_alias}'

--- a/dbt/adapters/bigquery/impl.py
+++ b/dbt/adapters/bigquery/impl.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Any, Set, Union, Type
 from dbt.dataclass_schema import dbtClassMixin, ValidationError
+copy_partitions: bool = False
 
 import dbt.deprecations
 import dbt.exceptions
@@ -536,11 +537,16 @@ class BigQueryAdapter(BaseAdapter):
         if not is_partitioned and not conf_partition:
             return True
         elif conf_partition and table.time_partitioning is not None:
-            partioning_field = table.time_partitioning.field or "_PARTITIONTIME"
-            table_field = partioning_field.lower()
+            partitioning_field = table.time_partitioning.field or "_PARTITIONTIME"
+            table_field = partitioning_field.lower()
             table_granularity = table.partitioning_type.lower()
+            conf_table_field = (
+                conf_partition.field
+                if not conf_partition.time_ingestion_partitioning
+                else "_PARTITIONTIME"
+            )            
             return (
-                table_field == conf_partition.field.lower()
+                table_field == conf_table_field.lower()
                 and table_granularity == conf_partition.granularity.lower()
             )
         elif conf_partition and table.range_partitioning is not None:

--- a/dbt/adapters/bigquery/impl.py
+++ b/dbt/adapters/bigquery/impl.py
@@ -248,12 +248,15 @@ class BigQueryAdapter(BaseAdapter):
             return []
 
     @available
-    def alias_column_name(self, column) -> str:
+    def alias_column(self, column) -> Dict[str, str]:
         "Alias pseudo columns to remove leading underscore"
+        alias = {'column': column, 'column_alias': None, 'statement': None}
         if column[0] == '_':
             column_alias = column.replace('_','',1)
-            column = column + f' as {column_alias}'
-        return column
+            statement = column + f' as {column_alias}'
+            alias['column_alias'] = column_alias 
+            alias['statement'] = statement
+        return alias
 
     @available.parse(lambda *a, **k: [])
     def add_time_ingestion_partition_column(self, columns) -> List[BigQueryColumn]:


### PR DESCRIPTION
resolves #365 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->

### Description

Added the `alias_column` method to the `BigQueryAdapter` class. 

The purpose of this method is to produce a column alias for use in a select statement or completely rename a provided column. The initial use case is for this to be used to alias [pseudo columns](https://cloud.google.com/bigquery/docs/external-data-cloud-storage#the_file_name_pseudo_column) so that dbt tests can be applied to them. If not aliased, BigQuery errors as it is trying to produce the dbt__test_audit table using a column name with an illegal character (preceding _).

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
