### PR TITLE
[CT-1412] docs_generate integration test hanging artifacts

### DIFF
--- a/tests/integration/docs_generate_tests/test_docs_generate.py
+++ b/tests/integration/docs_generate_tests/test_docs_generate.py
@@ -99,6 +99,8 @@ class TestDocsGenerate(DBTIntegrationTest):
         os.environ['DBT_ENV_CUSTOM_ENV_env_key'] = 'env_value'
 
     def tearDown(self):
+        with self.adapter.connection_named('__test'):
+            self._drop_schema_named(self.default_database, self.alternate_schema)
         super().tearDown()
         del os.environ['DBT_ENV_CUSTOM_ENV_env_key']
 
@@ -1837,7 +1839,7 @@ class TestDocsGenerate(DBTIntegrationTest):
             else:
                 self.assertIn(key, expected_manifest)  # sanity check
                 self.assertEqual(manifest[key], expected_manifest[key])
-                
+
     def _quote(self, value):
         quote_char = '`'
         return '{0}{1}{0}'.format(quote_char, value)
@@ -1942,7 +1944,6 @@ class TestDocsGenerate(DBTIntegrationTest):
     @use_profile('bigquery')
     def test__bigquery__run_and_generate(self):
         self.run_and_generate()
-
         self.verify_catalog(self.expected_bigquery_catalog())
         self.verify_manifest(self.expected_seeded_manifest())
         self.verify_run_results(self.expected_run_results())


### PR DESCRIPTION
resolves #360 

### Description

makes a fix to `tearDown` method to target alternate schema name before calling default `tearDown` method for integration test

spike doc: https://www.notion.so/dbtlabs/Bigquery-Leftover-tests-artifacts-350aa89a047f44b3b3b1967aaff8367e

todo:
- [ ] backport to 1.0.latest

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
