### PR TITLE
[CT-1405] Bigquery minor changes for event logging

### DIFF
--- a/.changes/unreleased/Under the Hood-20221207-103505.yaml
+++ b/.changes/unreleased/Under the Hood-20221207-103505.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: event logging changes to be in parity with dbt-core post pr#6291
+time: 2022-12-07T10:35:05.567885-06:00
+custom:
+  Author: McKnight-42
+  Issue: "6139"
+  PR: "410"

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -1,6 +1,5 @@
 import json
 import os
-import io
 import random
 import shutil
 import sys
@@ -8,6 +7,7 @@ import tempfile
 import traceback
 import unittest
 import warnings
+from io import StringIO
 from contextlib import contextmanager
 from datetime import datetime
 from functools import wraps
@@ -231,7 +231,7 @@ class DBTIntegrationTest(unittest.TestCase):
         return normalize(tempfile.mkdtemp(prefix='dbt-int-test-'))
 
     def setUp(self):
-        # Logbook warnings are ignored so we don't have to fork logbook to support python 3.10. 
+        # Logbook warnings are ignored so we don't have to fork logbook to support python 3.10.
         # This _only_ works for tests in `test/integration`.
         warnings.filterwarnings(
             "ignore",
@@ -417,7 +417,8 @@ class DBTIntegrationTest(unittest.TestCase):
 
     def run_dbt_and_capture(self, *args, **kwargs):
         try:
-            stringbuf = capture_stdout_logs()
+            stringbuf = StringIO()
+            capture_stdout_logs(stringbuf)
             res = self.run_dbt(*args, **kwargs)
             stdout = stringbuf.getvalue()
 


### PR DESCRIPTION
resolves #https://github.com/dbt-labs/dbt-core/issues/6139, https://github.com/dbt-labs/dbt-core/pull/6291


### Description
Minor changes to `run_dbt_and_capture` incorporating `StringIO` logic as a addition to the `capture_stdout_logs`  to be in parity with `dbt-core`
### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
