### PR TITLE
[BACKPORT] #411

### DIFF
--- a/.changes/unreleased/Under the Hood-20221207-151813.yaml
+++ b/.changes/unreleased/Under the Hood-20221207-151813.yaml
@@ -1,0 +1,8 @@
+kind: Under the Hood
+body: fix issue with tox 4.0.0 release which changes passenv syntax for space-separated
+  variables
+time: 2022-12-07T15:18:13.996118-06:00
+custom:
+  Author: McKnight-42
+  Issue: "411"
+  PR: "411"

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,8 @@ skip_install = true
 passenv =
     DBT_*
     BIGQUERY_TEST_*
-    PYTEST_ADDOPTS DATAPROC_*
+    PYTEST_ADDOPTS
+    DATAPROC_*
     GCS_BUCKET
 commands =
   bigquery: {envpython} -m pytest {posargs} -m profile_bigquery tests/integration

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,9 @@ envlist = py37,py38,py39
 [testenv:{unit,py37,py38,py39,py}]
 description = unit testing
 skip_install = true
-passenv = DBT_* PYTEST_ADDOPTS
+passenv =
+    DBT_*
+    PYTEST_ADDOPTS
 commands = {envpython} -m pytest {posargs} tests/unit
 deps =
   -rdev_requirements.txt
@@ -14,7 +16,11 @@ deps =
 [testenv:{integration,py37,py38,py39,py}-{bigquery}]
 description = adapter plugin integration testing
 skip_install = true
-passenv = DBT_* BIGQUERY_TEST_* PYTEST_ADDOPTS
+passenv =
+    DBT_*
+    BIGQUERY_TEST_*
+    PYTEST_ADDOPTS DATAPROC_*
+    GCS_BUCKET
 commands =
   bigquery: {envpython} -m pytest {posargs} -m profile_bigquery tests/integration
   bigquery: {envpython} -m pytest {posargs} tests/functional


### PR DESCRIPTION
resolves #


### Description

In tox 4, space-separated variables specified for passenv are not passed into the container.

```
[testenv:inline]
passenv = FOO BAR
☝️ doesn't work on tox 4
```

```
[testenv:separate-lines]
passenv =
    FOO
    BAR
```

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
