### PR TITLE
add pypi release to workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,22 +190,23 @@ jobs:
       changelog_path: ${{ inputs.changelog_path }}
       test_run: ${{ inputs.test_run }}
 
-# Skipping this for now until we've proven build work in the repos
-  # pypi-release:
-  #   name: Pypi release
+  pypi-release:
+    name: Pypi release
+    # only release to PyPi if we're not testing - will release to PyPi test when workflow gets rewritten
+    if: inputs.test_run  == 'false'
 
-  #   runs-on: ubuntu-latest
+    runs-on: ubuntu-latest
 
-  #   needs: github-release
+    needs: github-release
 
-  #   environment: PypiProd
-  #   steps:
-  #     - uses: actions/download-artifact@v2
-  #       with:
-  #         name: dist
-  #         path: 'dist'
+    environment: PypiProd
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: dist
+          path: 'dist'
 
-  #     - name: Publish distribution to PyPI
-  #       uses: pypa/gh-action-pypi-publish@v1.4.2
-  #       with:
-  #         password: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.4.2
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
### Description

Adds PyPi into release automation.  When `test_run` is true, it will not release to PyPi.  Test PyPi releases will be added at a future date.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
