### PR TITLE
Support all types of data_type using time ingestion partitioning

### DIFF
--- a/.changes/unreleased/Fixes-20230202-010912.yaml
+++ b/.changes/unreleased/Fixes-20230202-010912.yaml
@@ -1,0 +1,8 @@
+kind: Fixes
+body: Support all types of data_type using time ingestion partitioning as previously
+  `date` was failing
+time: 2023-02-02T01:09:12.013631+01:00
+custom:
+  Author: Kayrnt
+  Issue: "486"
+  PR: "496"

--- a/dbt/adapters/bigquery/impl.py
+++ b/dbt/adapters/bigquery/impl.py
@@ -78,25 +78,25 @@ class PartitionConfig(dbtClassMixin):
     copy_partitions: bool = False
 
     def data_type_for_partition(self):
-        """Return the data type of partitions for replacement."""
-        return self.data_type if not self.time_ingestion_partitioning else "timestamp"
+        """Return the data type of partitions for replacement.
+        When time_ingestion_partitioning is enabled, the data type supported are date & timestamp.
+        """
+        if not self.time_ingestion_partitioning:
+            return self.data_type
+        elif self.data_type.lower() == "date":
+            return "date"
+        else:
+            return "timestamp"
 
     def reject_partition_field_column(self, columns: List[Any]) -> List[str]:
         return [c for c in columns if not c.name.upper() == self.field.upper()]
 
     def data_type_should_be_truncated(self):
         """Return true if the data type should be truncated instead of cast to the data type."""
-        logger.info(
-            "data_type_should_be_truncated: {} / {}".format(
-                self.data_type.lower(), self.granularity.lower()
-            )
-        )
-        should_be = not (
+        return not (
             self.data_type.lower() == "int64"
             or (self.data_type.lower() == "date" and self.granularity.lower() == "day")
         )
-        logger.info("data_type_should_be_truncated: {}".format(should_be))
-        return should_be
 
     def time_partitioning_field(self) -> str:
         """Return the time partitioning field name based on the data type.

--- a/dbt/include/bigquery/macros/adapters.sql
+++ b/dbt/include/bigquery/macros/adapters.sql
@@ -65,12 +65,17 @@
         {{ get_table_columns_and_constraints() }}
         {%- set compiled_code = get_select_subquery(compiled_code) %}
       {% else %}
+        {#-- cannot do contracts at the same time as time ingestion partitioning -#}
         {{ columns }}
       {% endif %}
     {{ partition_by(partition_config) }}
     {{ cluster_by(raw_cluster_by) }}
 
     {{ bigquery_table_options(config, model, temporary) }}
+
+    {#-- PARTITION BY cannot be used with the AS query_statement clause.
+         https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#partition_expression
+    -#}
     {%- if not partition_config.time_ingestion_partitioning %}
     as (
       {{ compiled_code }}

--- a/dbt/include/bigquery/macros/adapters.sql
+++ b/dbt/include/bigquery/macros/adapters.sql
@@ -2,6 +2,8 @@
 {% macro partition_by(partition_config) -%}
     {%- if partition_config is none -%}
       {% do return('') %}
+    {%- elif partition_config.time_ingestion_partitioning -%}
+        partition by {{ partition_config.render_wrapped() }}
     {%- elif partition_config.data_type | lower in ('date','timestamp','datetime') -%}
         partition by {{ partition_config.render() }}
     {%- elif partition_config.data_type | lower in ('int64') -%}
@@ -48,6 +50,11 @@
     {%- set sql_header = config.get('sql_header', none) -%}
 
     {%- set partition_config = adapter.parse_partition_by(raw_partition_by) -%}
+    {%- if partition_config.time_ingestion_partitioning -%}
+    {%- set columns = get_columns_with_types_in_query_sql(sql) -%}
+    {%- set table_dest_columns_csv = columns_without_partition_fields_csv(partition_config, columns) -%}
+    {%- set columns = '(' ~ table_dest_columns_csv ~ ')' -%}
+    {%- endif -%}
 
     {{ sql_header if sql_header is not none }}
 
@@ -57,14 +64,18 @@
         {{ get_assert_columns_equivalent(compiled_code) }}
         {{ get_table_columns_and_constraints() }}
         {%- set compiled_code = get_select_subquery(compiled_code) %}
+      {% else %}
+        {{ columns }}
       {% endif %}
     {{ partition_by(partition_config) }}
     {{ cluster_by(raw_cluster_by) }}
 
     {{ bigquery_table_options(config, model, temporary) }}
+    {%- if not partition_config.time_ingestion_partitioning %}
     as (
       {{ compiled_code }}
     );
+    {%- endif %}
   {%- elif language == 'python' -%}
     {#--
     N.B. Python models _can_ write to temp views HOWEVER they use a different session

--- a/dbt/include/bigquery/macros/materializations/incremental.sql
+++ b/dbt/include/bigquery/macros/materializations/incremental.sql
@@ -22,18 +22,19 @@
   {%- endif -%}
 
 {% endmacro %}
-{% macro bq_create_table_as(is_time_ingestion_partitioning, temporary, relation, compiled_code, language='sql') %}
-  {% if is_time_ingestion_partitioning and language == 'python' %}
+
+{% macro bq_create_table_as(partition_by, temporary, relation, compiled_code, language='sql') %}
+  {%- set _dbt_max_partition = declare_dbt_max_partition(this, partition_by, compiled_code, language) -%}
+  {% if partition_by.time_ingestion_partitioning and language == 'python' %}
     {% do exceptions.raise_compiler_error(
       "Python models do not support ingestion time partitioning"
     ) %}
-  {% endif %}
-  {% if is_time_ingestion_partitioning and language == 'sql' %}
+  {% elif partition_by.time_ingestion_partitioning and language == 'sql' %}
     {#-- Create the table before inserting data as ingestion time partitioned tables can't be created with the transformed data --#}
     {% do run_query(create_table_as(temporary, relation, compiled_code)) %}
-    {{ return(bq_insert_into_ingestion_time_partitioned_table_sql(relation, compiled_code)) }}
+    {{ return(_dbt_max_partition + bq_insert_into_ingestion_time_partitioned_table_sql(relation, compiled_code)) }}
   {% else %}
-    {{ return(create_table_as(temporary, relation, compiled_code, language)) }}
+    {{ return(_dbt_max_partition + create_table_as(temporary, relation, compiled_code, language)) }}
   {% endif %}
 {% endmacro %}
 
@@ -93,14 +94,14 @@
 
   {% elif existing_relation is none %}
       {%- call statement('main', language=language) -%}
-        {{ bq_create_table_as(partition_by.time_ingestion_partitioning, False, target_relation, compiled_code, language) }}
+        {{ bq_create_table_as(partition_by, False, target_relation, compiled_code, language) }}
       {%- endcall -%}
 
   {% elif existing_relation.is_view %}
       {#-- There's no way to atomically replace a view with a table on BQ --#}
       {{ adapter.drop_relation(existing_relation) }}
       {%- call statement('main', language=language) -%}
-        {{ bq_create_table_as(partition_by.time_ingestion_partitioning, False, target_relation, compiled_code, language) }}
+        {{ bq_create_table_as(partition_by, False, target_relation, compiled_code, language) }}
       {%- endcall -%}
 
   {% elif full_refresh_mode %}
@@ -110,7 +111,7 @@
           {{ adapter.drop_relation(existing_relation) }}
       {% endif %}
       {%- call statement('main', language=language) -%}
-        {{ bq_create_table_as(partition_by.time_ingestion_partitioning, False, target_relation, compiled_code, language) }}
+        {{ bq_create_table_as(partition_by, False, target_relation, compiled_code, language) }}
       {%- endcall -%}
 
   {% else %}
@@ -127,9 +128,7 @@
       {#-- Check first, since otherwise we may not build a temp table --#}
       {#-- Python always needs to create a temp table --#}
       {%- call statement('create_tmp_relation', language=language) -%}
-        {{ declare_dbt_max_partition(this, partition_by, compiled_code, language) +
-           bq_create_table_as(partition_by.time_ingestion_partitioning, True, tmp_relation, compiled_code, language)
-        }}
+        {{ bq_create_table_as(partition_by, True, tmp_relation, compiled_code, language) }}
       {%- endcall -%}
       {% set tmp_relation_exists = true %}
       {#-- Process schema changes. Returns dict of changes if successful. Use source columns for upserting/merging --#}
@@ -139,9 +138,11 @@
     {% if not dest_columns %}
       {% set dest_columns = adapter.get_columns_in_relation(existing_relation) %}
     {% endif %}
+    {#--  Add time ingestion pseudo column to destination column as not part of the 'schema' but still need it for actual data insertion --#}
     {% if partition_by.time_ingestion_partitioning %}
       {% set dest_columns = adapter.add_time_ingestion_partition_column(partition_by, dest_columns) %}
     {% endif %}
+
     {% set build_sql = bq_generate_incremental_build_sql(
         strategy, tmp_relation, target_relation, compiled_code, unique_key, partition_by, partitions, dest_columns, tmp_relation_exists, partition_by.copy_partitions, incremental_predicates
     ) %}

--- a/dbt/include/bigquery/macros/materializations/incremental_strategy/common.sql
+++ b/dbt/include/bigquery/macros/materializations/incremental_strategy/common.sql
@@ -1,12 +1,3 @@
-{% macro build_partition_time_exp(partition_by) %}
-  {% if partition_by.data_type == 'timestamp' %}
-    {% set partition_value = partition_by.field %}
-  {% else %}
-    {% set partition_value = 'timestamp(' + partition_by.field + ')' %}
-  {% endif %}
-  {{ return({'value': partition_value, 'field': partition_by.field}) }}
-{% endmacro %}
-
 {% macro declare_dbt_max_partition(relation, partition_by, compiled_code, language='sql') %}
 
   {#-- TODO: revisit partitioning with python models --#}

--- a/dbt/include/bigquery/macros/materializations/incremental_strategy/insert_overwrite.sql
+++ b/dbt/include/bigquery/macros/materializations/incremental_strategy/insert_overwrite.sql
@@ -85,8 +85,7 @@
   ) %}
   {# We run temp table creation in a separated script to move to partitions copy #}
   {%- call statement('create_tmp_relation_for_copy', language='sql') -%}
-    {{ declare_dbt_max_partition(this, partition_by, sql, 'sql') +
-     bq_create_table_as(partition_by.time_ingestion_partitioning, True, tmp_relation, sql, 'sql')
+    {{ bq_create_table_as(partition_by, True, tmp_relation, sql, 'sql')
   }}
   {%- endcall %}
   {%- set partitions_sql -%}
@@ -123,19 +122,18 @@
 
       {# have we already created the temp table to check for schema changes? #}
       {% if not tmp_relation_exists %}
-        {{ declare_dbt_max_partition(this, partition_by, sql) }}
-
        -- 1. create a temp table with model data
-        {{ bq_create_table_as(partition_by.time_ingestion_partitioning, True, tmp_relation, sql, 'sql') }}
+        {{ bq_create_table_as(partition_by, True, tmp_relation, sql, 'sql') }}
       {% else %}
         -- 1. temp table already exists, we used it to check for schema changes
       {% endif %}
+      {%- set partition_field = partition_by.time_partitioning_field() if partition_by.time_ingestion_partitioning else partition_by.render_wrapped() -%}
 
       -- 2. define partitions to update
       set (dbt_partitions_for_replacement) = (
           select as struct
               -- IGNORE NULLS: this needs to be aligned to _dbt_max_partition, which ignores null
-              array_agg(distinct {{ partition_by.render_wrapped() }} IGNORE NULLS)
+              array_agg(distinct {{ partition_field }} IGNORE NULLS)
           from {{ tmp_relation }}
       );
 

--- a/dbt/include/bigquery/macros/materializations/incremental_strategy/insert_overwrite.sql
+++ b/dbt/include/bigquery/macros/materializations/incremental_strategy/insert_overwrite.sql
@@ -58,7 +58,7 @@
       {%- set source_sql -%}
         (
           {%- if partition_by.time_ingestion_partitioning -%}
-          {{ wrap_with_time_ingestion_partitioning_sql(build_partition_time_exp(partition_by), sql, True) }}
+          {{ wrap_with_time_ingestion_partitioning_sql(partition_by, sql, True) }}
           {%- else -%}
           {{sql}}
           {%- endif -%}
@@ -112,7 +112,7 @@
       (
         select
         {% if partition_by.time_ingestion_partitioning -%}
-        _PARTITIONTIME,
+        {{ partition_by.insertable_time_partitioning_field() }},
         {%- endif -%}
         * from {{ tmp_relation }}
       )

--- a/dbt/include/bigquery/macros/materializations/incremental_strategy/merge.sql
+++ b/dbt/include/bigquery/macros/materializations/incremental_strategy/merge.sql
@@ -6,14 +6,14 @@
         (
         select
         {% if partition_by.time_ingestion_partitioning -%}
-        _PARTITIONTIME,
+        {{ partition_by.insertable_time_partitioning_field() }},
         {%- endif -%}
         * from {{ tmp_relation }}
         )
         {%- else -%} {#-- wrap sql in parens to make it a subquery --#}
         (
             {%- if partition_by.time_ingestion_partitioning -%}
-            {{ wrap_with_time_ingestion_partitioning_sql(build_partition_time_exp(partition_by), sql, True) }}
+            {{ wrap_with_time_ingestion_partitioning_sql(partition_by, sql, True) }}
             {%- else -%}
             {{sql}}
             {%- endif %}

--- a/dbt/include/bigquery/macros/materializations/incremental_strategy/time_ingestion_tables.sql
+++ b/dbt/include/bigquery/macros/materializations/incremental_strategy/time_ingestion_tables.sql
@@ -1,34 +1,10 @@
-{% macro wrap_with_time_ingestion_partitioning_sql(partition_time_exp, sql, is_nested) %}
+{% macro wrap_with_time_ingestion_partitioning_sql(partition_by, sql, is_nested) %}
 
-  select {{ partition_time_exp['value'] }} as _partitiontime, * EXCEPT({{ partition_time_exp['field'] }}) from (
+  select TIMESTAMP({{ partition_by.field }}) as {{ partition_by.insertable_time_partitioning_field() }}, * EXCEPT({{ partition_by.field }}) from (
     {{ sql }}
   ){%- if not is_nested -%};{%- endif -%}
 
 {% endmacro %}
-
-{% macro create_ingestion_time_partitioned_table_as_sql(temporary, relation, sql) -%}
-  {%- set raw_partition_by = config.get('partition_by', none) -%}
-  {%- set raw_cluster_by = config.get('cluster_by', none) -%}
-  {%- set sql_header = config.get('sql_header', none) -%}
-
-  {%- set partition_config = adapter.parse_partition_by(raw_partition_by) -%}
-
-  {%- set columns = get_columns_with_types_in_query_sql(sql) -%}
-  {%- set table_dest_columns_csv = columns_without_partition_fields_csv(partition_config, columns) -%}
-
-  {{ sql_header if sql_header is not none }}
-
-  {% set ingestion_time_partition_config_raw = fromjson(tojson(raw_partition_by)) %}
-  {% do ingestion_time_partition_config_raw.update({'field':'_PARTITIONTIME'}) %}
-
-  {%- set ingestion_time_partition_config = adapter.parse_partition_by(ingestion_time_partition_config_raw) -%}
-
-  create or replace table {{ relation }} ({{table_dest_columns_csv}})
-  {{ partition_by(ingestion_time_partition_config) }}
-  {{ cluster_by(raw_cluster_by) }}
-  {{ bigquery_table_options(config, model, temporary) }}
-
-{%- endmacro -%}
 
 {% macro get_quoted_with_types_csv(columns) %}
     {% set quoted = [] %}
@@ -48,12 +24,13 @@
 {%- endmacro -%}
 
 {% macro bq_insert_into_ingestion_time_partitioned_table_sql(target_relation, sql) -%}
-  {%- set partition_by = config.get('partition_by', none) -%}
+  {%- set raw_partition_by = config.get('partition_by', none) -%}
+  {%- set partition_by = adapter.parse_partition_by(raw_partition_by) -%}
   {% set dest_columns = adapter.get_columns_in_relation(target_relation) %}
   {%- set dest_columns_csv = get_quoted_csv(dest_columns | map(attribute="name")) -%}
 
-  insert into {{ target_relation }} (_partitiontime, {{ dest_columns_csv }})
-    {{ wrap_with_time_ingestion_partitioning_sql(build_partition_time_exp(partition_by), sql, False) }}
+  insert into {{ target_relation }} ({{ partition_by.insertable_time_partitioning_field() }}, {{ dest_columns_csv }})
+    {{ wrap_with_time_ingestion_partitioning_sql(partition_by, sql, False) }}
 
 {%- endmacro -%}
 

--- a/tests/functional/adapter/incremental/incremental_strategy_fixtures.py
+++ b/tests/functional/adapter/incremental/incremental_strategy_fixtures.py
@@ -54,7 +54,7 @@ merge_time_sql = """
         cluster_by="id",
         partition_by={
             "field": "date_time",
-            "data_type": "datetime"
+            "data_type": "dateTime"
         }
     )
 }}

--- a/tests/functional/adapter/incremental/incremental_strategy_fixtures.py
+++ b/tests/functional/adapter/incremental/incremental_strategy_fixtures.py
@@ -260,42 +260,7 @@ with data as (
 select * from data
 
 {% if is_incremental() %}
-where date_day >= _dbt_max_partition
-{% endif %}
-""".lstrip()
-
-overwrite_day_with_time_ingestion_sql = """
-{{
-    config(
-        materialized="incremental",
-        incremental_strategy='insert_overwrite',
-        cluster_by="id",
-        partition_by={
-            "field": "date_time",
-            "data_type": "datetime",
-            "time_ingestion_partitioning": true
-        },
-        require_partition_filter=true
-    )
-}}
-with data as (
-    {% if not is_incremental() %}
-        select 1 as id, cast('2020-01-01' as datetime) as date_time union all
-        select 2 as id, cast('2020-01-01' as datetime) as date_time union all
-        select 3 as id, cast('2020-01-01' as datetime) as date_time union all
-        select 4 as id, cast('2020-01-01' as datetime) as date_time
-    {% else %}
-        -- we want to overwrite the 4 records in the 2020-01-01 partition
-        -- with the 2 records below, but add two more in the 2020-01-02 partition
-        select 10 as id, cast('2020-01-01' as datetime) as date_time union all
-        select 20 as id, cast('2020-01-01' as datetime) as date_time union all
-        select 30 as id, cast('2020-01-02' as datetime) as date_time union all
-        select 40 as id, cast('2020-01-02' as datetime) as date_time
-    {% endif %}
-)
-select * from data
-{% if is_incremental() %}
-where date_time > '2020-01-01'
+where date_day >= '2020-01-01'
 {% endif %}
 """.lstrip()
 
@@ -435,7 +400,7 @@ where date_hour >= _dbt_max_partition
 {% endif %}
 """.lstrip()
 
-overwrite_day_with_partition_sql = """
+overwrite_day_with_time_ingestion_sql = """
 {{
     config(
         materialized="incremental",

--- a/tests/functional/adapter/incremental/test_incremental_strategies.py
+++ b/tests/functional/adapter/incremental/test_incremental_strategies.py
@@ -24,6 +24,7 @@ from tests.functional.adapter.incremental.incremental_strategy_fixtures import (
     overwrite_range_sql,
     overwrite_time_sql,
     overwrite_day_with_time_ingestion_sql,
+    overwrite_day_with_time_partition_datetime_sql
 )
 
 
@@ -43,7 +44,8 @@ class TestBigQueryScripting(SeedConfigBase):
             "incremental_overwrite_partitions.sql": overwrite_partitions_sql,
             "incremental_overwrite_range.sql": overwrite_range_sql,
             "incremental_overwrite_time.sql": overwrite_time_sql,
-            "incremental_overwrite_day_with_time_ingestion.sql": overwrite_day_with_time_ingestion_sql,
+            "incremental_overwrite_day_with_time_partition.sql": overwrite_day_with_time_ingestion_sql,
+            "incremental_overwrite_day_with_time_partition_datetime.sql": overwrite_day_with_time_partition_datetime_sql
         }
 
     @pytest.fixture(scope="class")
@@ -55,16 +57,17 @@ class TestBigQueryScripting(SeedConfigBase):
             "incremental_overwrite_date_expected.csv": seed_incremental_overwrite_date_expected_csv,
             "incremental_overwrite_day_expected.csv": seed_incremental_overwrite_day_expected_csv,
             "incremental_overwrite_range_expected.csv": seed_incremental_overwrite_range_expected_csv,
-            "incremental_overwrite_day_with_time_partition_expected.csv": seed_incremental_overwrite_day_with_time_partition_expected_csv,
+            "incremental_overwrite_day_with_time_partition_expected.csv":
+                seed_incremental_overwrite_day_with_time_partition_expected_csv
         }
 
     def test__bigquery_assert_incremental_configurations_apply_the_right_strategy(self, project):
         run_dbt(["seed"])
         results = run_dbt()
-        assert len(results) == 9
+        assert len(results) == 10
 
         results = run_dbt()
-        assert len(results) == 9
+        assert len(results) == 10
         incremental_strategies = [
             ("incremental_merge_range", "merge_expected"),
             ("incremental_merge_time", "merge_expected"),
@@ -73,6 +76,8 @@ class TestBigQueryScripting(SeedConfigBase):
             ("incremental_overwrite_partitions", "incremental_overwrite_date_expected"),
             ("incremental_overwrite_day", "incremental_overwrite_day_expected"),
             ("incremental_overwrite_range", "incremental_overwrite_range_expected"),
+            ("incremental_overwrite_day_with_time_partition", "incremental_overwrite_day_with_time_partition_expected"),
+            ("incremental_overwrite_day_with_time_partition_datetime", "incremental_overwrite_day_with_time_partition_expected"),
         ]
         db_with_schema = f"{project.database}.{project.test_schema}"
         for incremental_strategy in incremental_strategies:

--- a/tests/functional/adapter/incremental/test_incremental_strategies.py
+++ b/tests/functional/adapter/incremental/test_incremental_strategies.py
@@ -24,7 +24,7 @@ from tests.functional.adapter.incremental.incremental_strategy_fixtures import (
     overwrite_range_sql,
     overwrite_time_sql,
     overwrite_day_with_time_ingestion_sql,
-    overwrite_day_with_time_partition_datetime_sql
+    overwrite_day_with_time_partition_datetime_sql,
 )
 
 
@@ -45,7 +45,7 @@ class TestBigQueryScripting(SeedConfigBase):
             "incremental_overwrite_range.sql": overwrite_range_sql,
             "incremental_overwrite_time.sql": overwrite_time_sql,
             "incremental_overwrite_day_with_time_partition.sql": overwrite_day_with_time_ingestion_sql,
-            "incremental_overwrite_day_with_time_partition_datetime.sql": overwrite_day_with_time_partition_datetime_sql
+            "incremental_overwrite_day_with_time_partition_datetime.sql": overwrite_day_with_time_partition_datetime_sql,
         }
 
     @pytest.fixture(scope="class")
@@ -57,8 +57,7 @@ class TestBigQueryScripting(SeedConfigBase):
             "incremental_overwrite_date_expected.csv": seed_incremental_overwrite_date_expected_csv,
             "incremental_overwrite_day_expected.csv": seed_incremental_overwrite_day_expected_csv,
             "incremental_overwrite_range_expected.csv": seed_incremental_overwrite_range_expected_csv,
-            "incremental_overwrite_day_with_time_partition_expected.csv":
-                seed_incremental_overwrite_day_with_time_partition_expected_csv
+            "incremental_overwrite_day_with_time_partition_expected.csv": seed_incremental_overwrite_day_with_time_partition_expected_csv,
         }
 
     def test__bigquery_assert_incremental_configurations_apply_the_right_strategy(self, project):
@@ -76,8 +75,10 @@ class TestBigQueryScripting(SeedConfigBase):
             ("incremental_overwrite_partitions", "incremental_overwrite_date_expected"),
             ("incremental_overwrite_day", "incremental_overwrite_day_expected"),
             ("incremental_overwrite_range", "incremental_overwrite_range_expected"),
-            ("incremental_overwrite_day_with_time_partition", "incremental_overwrite_day_with_time_partition_expected"),
-            ("incremental_overwrite_day_with_time_partition_datetime", "incremental_overwrite_day_with_time_partition_expected"),
+            (
+                "incremental_overwrite_day_with_time_partition_datetime",
+                "incremental_overwrite_day_with_time_partition_expected",
+            ),
         ]
         db_with_schema = f"{project.database}.{project.test_schema}"
         for incremental_strategy in incremental_strategies:
@@ -91,4 +92,12 @@ class TestBigQueryScripting(SeedConfigBase):
             project.adapter, "incremental_overwrite_day_with_copy_partitions"
         )
         expected = get_relation_columns(project.adapter, "incremental_overwrite_day_expected")
+        assert created == expected
+
+        created = get_relation_columns(
+            project.adapter, "incremental_overwrite_day_with_time_partition"
+        )
+        expected = get_relation_columns(
+            project.adapter, "incremental_overwrite_day_with_time_partition_expected"
+        )
         assert created == expected

--- a/tests/unit/test_bigquery_adapter.py
+++ b/tests/unit/test_bigquery_adapter.py
@@ -752,7 +752,7 @@ class TestBigQueryAdapter(BaseTestBigQueryAdapter):
             {
                 "field": "ts",
                 "data_type": "date",
-                "granularity": "MONTH",
+                "granularity": "month",
                 "time_ingestion_partitioning": False,
                 "copy_partitions": False,
             },
@@ -765,7 +765,7 @@ class TestBigQueryAdapter(BaseTestBigQueryAdapter):
             {
                 "field": "ts",
                 "data_type": "date",
-                "granularity": "YEAR",
+                "granularity": "year",
                 "time_ingestion_partitioning": False,
                 "copy_partitions": False,
             },
@@ -778,7 +778,7 @@ class TestBigQueryAdapter(BaseTestBigQueryAdapter):
             {
                 "field": "ts",
                 "data_type": "timestamp",
-                "granularity": "HOUR",
+                "granularity": "hour",
                 "time_ingestion_partitioning": False,
                 "copy_partitions": False,
             },
@@ -791,7 +791,7 @@ class TestBigQueryAdapter(BaseTestBigQueryAdapter):
             {
                 "field": "ts",
                 "data_type": "timestamp",
-                "granularity": "MONTH",
+                "granularity": "month",
                 "time_ingestion_partitioning": False,
                 "copy_partitions": False,
             },
@@ -804,7 +804,7 @@ class TestBigQueryAdapter(BaseTestBigQueryAdapter):
             {
                 "field": "ts",
                 "data_type": "timestamp",
-                "granularity": "YEAR",
+                "granularity": "year",
                 "time_ingestion_partitioning": False,
                 "copy_partitions": False,
             },
@@ -817,7 +817,7 @@ class TestBigQueryAdapter(BaseTestBigQueryAdapter):
             {
                 "field": "ts",
                 "data_type": "datetime",
-                "granularity": "HOUR",
+                "granularity": "hour",
                 "time_ingestion_partitioning": False,
                 "copy_partitions": False,
             },
@@ -830,7 +830,7 @@ class TestBigQueryAdapter(BaseTestBigQueryAdapter):
             {
                 "field": "ts",
                 "data_type": "datetime",
-                "granularity": "MONTH",
+                "granularity": "month",
                 "time_ingestion_partitioning": False,
                 "copy_partitions": False,
             },
@@ -843,7 +843,7 @@ class TestBigQueryAdapter(BaseTestBigQueryAdapter):
             {
                 "field": "ts",
                 "data_type": "datetime",
-                "granularity": "YEAR",
+                "granularity": "year",
                 "time_ingestion_partitioning": False,
                 "copy_partitions": False,
             },


### PR DESCRIPTION
resolves #486

### Description

This PR refactors the usage of time ingestion partitioning to use the actual data_type to pick the right pseudo column (_PARTITIONTIME for timestamp/datetime & _PARTITIONDATE for date)

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
