### PR TITLE
specify 1.1 in batch runtime config

### DIFF
--- a/.changes/unreleased/Fixes-20230213-203317.yaml
+++ b/.changes/unreleased/Fixes-20230213-203317.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Pin dataproc serverless spark runtime to `1.1`
+time: 2023-02-13T20:33:17.839861-08:00
+custom:
+  Author: colin-rogers-dbt
+  Issue: "531"

--- a/dbt/adapters/bigquery/python_submissions.py
+++ b/dbt/adapters/bigquery/python_submissions.py
@@ -121,7 +121,8 @@ class ServerlessDataProcHelper(BaseDataProcHelper):
 
     def _submit_dataproc_job(self) -> dataproc_v1.types.jobs.Job:
         # create the Dataproc Serverless job config
-        batch = dataproc_v1.Batch()
+        # need to pin dataproc version to 1.1 as it now defaults to 2.0
+        batch = dataproc_v1.Batch({'runtime_config': dataproc_v1.RuntimeConfig(version="1.1")})
         batch.pyspark_batch.main_python_file_uri = self.gcs_location
         # how to keep this up to date?
         # we should probably also open this up to be configurable

--- a/dbt/adapters/bigquery/python_submissions.py
+++ b/dbt/adapters/bigquery/python_submissions.py
@@ -122,7 +122,7 @@ class ServerlessDataProcHelper(BaseDataProcHelper):
     def _submit_dataproc_job(self) -> dataproc_v1.types.jobs.Job:
         # create the Dataproc Serverless job config
         # need to pin dataproc version to 1.1 as it now defaults to 2.0
-        batch = dataproc_v1.Batch({'runtime_config': dataproc_v1.RuntimeConfig(version="1.1")})
+        batch = dataproc_v1.Batch({"runtime_config": dataproc_v1.RuntimeConfig(version="1.1")})
         batch.pyspark_batch.main_python_file_uri = self.gcs_location
         # how to keep this up to date?
         # we should probably also open this up to be configurable


### PR DESCRIPTION
resolves #531

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->

### Description
GCP changed the default spark runtime version from 1.1 to 2.0 introducing some breaking changes. 
<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
