### PR TITLE
[ADAP-353]: Fix for #581: Python incremental model

### DIFF
--- a/.changes/unreleased/Fixes-20230309-181313.yaml
+++ b/.changes/unreleased/Fixes-20230309-181313.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix for Python incremental model regression
+time: 2023-03-09T18:13:13.512904-08:00
+custom:
+  Author: nssalian
+  Issue: "581"

--- a/dbt/adapters/bigquery/impl.py
+++ b/dbt/adapters/bigquery/impl.py
@@ -900,7 +900,7 @@ class BigQueryAdapter(BaseAdapter):
 
     @property
     def default_python_submission_method(self) -> str:
-        return "cluster"
+        return "serverless"
 
     @property
     def python_submission_helpers(self) -> Dict[str, Type[PythonJobHelper]]:

--- a/dbt/adapters/bigquery/impl.py
+++ b/dbt/adapters/bigquery/impl.py
@@ -900,7 +900,7 @@ class BigQueryAdapter(BaseAdapter):
 
     @property
     def default_python_submission_method(self) -> str:
-        return "serverless"
+        return "cluster"
 
     @property
     def python_submission_helpers(self) -> Dict[str, Type[PythonJobHelper]]:

--- a/dbt/include/bigquery/macros/materializations/incremental.sql
+++ b/dbt/include/bigquery/macros/materializations/incremental.sql
@@ -29,7 +29,6 @@
     ) %}
   {% endif %}
   {% if is_time_ingestion_partitioning and language == 'sql' %}
-    {#-- not supported yet for python language models}
     {#-- Create the table before inserting data as ingestion time partitioned tables can't be created with the transformed data --#}
     {% do run_query(create_ingestion_time_partitioned_table_as_sql(temporary, relation, compiled_code)) %}
     {{ return(bq_insert_into_ingestion_time_partitioned_table_sql(relation, compiled_code)) }}

--- a/dbt/include/bigquery/macros/materializations/incremental.sql
+++ b/dbt/include/bigquery/macros/materializations/incremental.sql
@@ -23,6 +23,11 @@
 
 {% endmacro %}
 {% macro bq_create_table_as(is_time_ingestion_partitioning, temporary, relation, compiled_code, language='sql') %}
+  {% if is_time_ingestion_partitioning and language == 'python' %}
+    {% do exceptions.raise_compiler_error(
+      "Python models do not support ingestion time partitioning"
+    ) %}
+  {% endif %}
   {% if is_time_ingestion_partitioning and language == 'sql' %}
     {#-- not supported yet for python language models}
     {#-- Create the table before inserting data as ingestion time partitioned tables can't be created with the transformed data --#}

--- a/dbt/include/bigquery/macros/materializations/incremental.sql
+++ b/dbt/include/bigquery/macros/materializations/incremental.sql
@@ -1,3 +1,5 @@
+-- noinspection SqlNoDataSourceInspectionForFile
+
 {% macro dbt_bigquery_validate_get_incremental_strategy(config) %}
   {#-- Find and validate the incremental strategy #}
   {%- set strategy = config.get("incremental_strategy") or 'merge' -%}
@@ -23,12 +25,12 @@
 
 {% endmacro %}
 {% macro bq_create_table_as(is_time_ingestion_partitioning, temporary, relation, compiled_code, language='sql') %}
-  {% if is_time_ingestion_partitioning %}
+  {% if is_time_ingestion_partitioning and language == 'sql' %}
     {#-- Create the table before inserting data as ingestion time partitioned tables can't be created with the transformed data --#}
-    {% do run_query(create_ingestion_time_partitioned_table_as_sql(temporary, relation, sql)) %}
-    {{ return(bq_insert_into_ingestion_time_partitioned_table_sql(relation, sql)) }}
+    {% do run_query(create_ingestion_time_partitioned_table_as_sql(temporary, relation, compiled_code)) %}
+    {{ return(bq_insert_into_ingestion_time_partitioned_table_sql(relation, compiled_code)) }}
   {% else %}
-    {{ return(create_table_as(temporary, relation, sql)) }}
+    {{ return(create_table_as(temporary, relation, compiled_code, language)) }}
   {% endif %}
 {% endmacro %}
 

--- a/dbt/include/bigquery/macros/materializations/incremental.sql
+++ b/dbt/include/bigquery/macros/materializations/incremental.sql
@@ -1,5 +1,3 @@
--- noinspection SqlNoDataSourceInspectionForFile
-
 {% macro dbt_bigquery_validate_get_incremental_strategy(config) %}
   {#-- Find and validate the incremental strategy #}
   {%- set strategy = config.get("incremental_strategy") or 'merge' -%}

--- a/dbt/include/bigquery/macros/materializations/incremental.sql
+++ b/dbt/include/bigquery/macros/materializations/incremental.sql
@@ -26,6 +26,7 @@
 {% endmacro %}
 {% macro bq_create_table_as(is_time_ingestion_partitioning, temporary, relation, compiled_code, language='sql') %}
   {% if is_time_ingestion_partitioning and language == 'sql' %}
+    {#-- not supported yet for python language models}
     {#-- Create the table before inserting data as ingestion time partitioned tables can't be created with the transformed data --#}
     {% do run_query(create_ingestion_time_partitioned_table_as_sql(temporary, relation, compiled_code)) %}
     {{ return(bq_insert_into_ingestion_time_partitioned_table_sql(relation, compiled_code)) }}

--- a/tests/functional/adapter/test_python_model.py
+++ b/tests/functional/adapter/test_python_model.py
@@ -3,6 +3,7 @@ import pytest
 from dbt.tests.util import run_dbt, write_file
 import dbt.tests.adapter.python_model.test_python_model as dbt_tests
 
+
 class TestPythonModelDataproc(dbt_tests.BasePythonModelTests):
     pass
 

--- a/tests/functional/adapter/test_python_model.py
+++ b/tests/functional/adapter/test_python_model.py
@@ -34,6 +34,7 @@ def model(dbt, spark):
 """
 
 
+@pytest.mark.skip(reason="Might need fixing")
 class TestChangingSchemaDataproc:
 
     @pytest.fixture(scope="class")

--- a/tests/functional/adapter/test_python_model.py
+++ b/tests/functional/adapter/test_python_model.py
@@ -3,11 +3,16 @@ import pytest
 from dbt.tests.util import run_dbt, write_file
 import dbt.tests.adapter.python_model.test_python_model as dbt_tests
 
+TEST_SKIP_MESSAGE = "Skipping the Tests since Dataproc serverless is not stable. " \
+                    "TODO: Fix later"
 
+
+@pytest.mark.skip(reason=TEST_SKIP_MESSAGE)
 class TestPythonModelDataproc(dbt_tests.BasePythonModelTests):
     pass
 
 
+@pytest.mark.skip(reason=TEST_SKIP_MESSAGE)
 class TestPythonIncrementalMatsDataproc(dbt_tests.BasePythonIncrementalTests):
     pass
 
@@ -35,6 +40,7 @@ def model(dbt, spark):
 """
 
 
+@pytest.mark.skip(reason=TEST_SKIP_MESSAGE)
 class TestChangingSchemaDataproc:
 
     @pytest.fixture(scope="class")

--- a/tests/functional/adapter/test_python_model.py
+++ b/tests/functional/adapter/test_python_model.py
@@ -34,7 +34,6 @@ def model(dbt, spark):
 """
 
 
-@pytest.mark.skip(reason="Might need fixing")
 class TestChangingSchemaDataproc:
 
     @pytest.fixture(scope="class")

--- a/tests/functional/adapter/test_python_model.py
+++ b/tests/functional/adapter/test_python_model.py
@@ -3,13 +3,10 @@ import pytest
 from dbt.tests.util import run_dbt, write_file
 import dbt.tests.adapter.python_model.test_python_model as dbt_tests
 
-# ToDo: Fix and schedule these tests:
-# https://github.com/dbt-labs/dbt-bigquery/issues/306
 class TestPythonModelDataproc(dbt_tests.BasePythonModelTests):
     pass
 
 
-@pytest.mark.skip(reason="Currently Broken")
 class TestPythonIncrementalMatsDataproc(dbt_tests.BasePythonIncrementalTests):
     pass
 

--- a/tests/functional/adapter/test_python_model.py
+++ b/tests/functional/adapter/test_python_model.py
@@ -34,7 +34,6 @@ def model(dbt, spark):
 """
 
 
-@pytest.mark.skip(reason="Currently Broken")
 class TestChangingSchemaDataproc:
 
     @pytest.fixture(scope="class")

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,8 @@ passenv =
     DBT_*
     BIGQUERY_TEST_*
     PYTEST_ADDOPTS
+    DATAPROC_*
+    GCS_BUCKET
 commands =
   bigquery: {envpython} -m pytest {posargs} -vv tests/functional --profile service_account
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ passenv =
     BIGQUERY_TEST_*
     PYTEST_ADDOPTS
 commands =
-  bigquery: {envpython} -m pytest {posargs} -vv tests/functional -k "not TestPython" --profile service_account
+  bigquery: {envpython} -m pytest {posargs} -vv tests/functional --profile service_account
 deps =
   -rdev-requirements.txt
   -e.


### PR DESCRIPTION
resolves #581 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->

### Description

The macro `bq_create_table_as` wasn't passing the compiled_code through into the underlying method
Note: Skipping the tests for now since the Dataproc serverless hasn't been stable. A follow-up PR should be moving the tests for python to execute on cluster only. All tests pass on the [Cluster mode run](https://github.com/dbt-labs/dbt-bigquery/actions/runs/4380640163/jobs/7667923167)

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
