### PR TITLE
Configuring the python model tests to execute on Dataproc cluster instead of serverless

### DIFF
--- a/.changes/unreleased/Under the Hood-20230310-130816.yaml
+++ b/.changes/unreleased/Under the Hood-20230310-130816.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Change to allow running python model tests on dataproc cluster instead of serverless
+time: 2023-03-10T13:08:16.95936-08:00
+custom:
+  Author: nssalian
+  Issue: "581"

--- a/tests/functional/adapter/test_python_model.py
+++ b/tests/functional/adapter/test_python_model.py
@@ -3,16 +3,20 @@ import pytest
 from dbt.tests.util import run_dbt, write_file
 import dbt.tests.adapter.python_model.test_python_model as dbt_tests
 
-TEST_SKIP_MESSAGE = "Skipping the Tests since Dataproc serverless is not stable. " \
-                    "TODO: Fix later"
+
+@pytest.fixture(scope="module")
+def project_config_update():
+    return {
+        "models": {
+            "+submission_method": "cluster"
+        }
+    }
 
 
-@pytest.mark.skip(reason=TEST_SKIP_MESSAGE)
 class TestPythonModelDataproc(dbt_tests.BasePythonModelTests):
     pass
 
 
-@pytest.mark.skip(reason=TEST_SKIP_MESSAGE)
 class TestPythonIncrementalMatsDataproc(dbt_tests.BasePythonIncrementalTests):
     pass
 
@@ -40,9 +44,7 @@ def model(dbt, spark):
 """
 
 
-@pytest.mark.skip(reason=TEST_SKIP_MESSAGE)
 class TestChangingSchemaDataproc:
-
     @pytest.fixture(scope="class")
     def models(self):
         return {

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ passenv =
     DATAPROC_*
     GCS_BUCKET
 commands =
-  {envpython} -m pytest {posargs} -vv tests/functional -k "TestPython" --profile service_account
+  {envpython} -m pytest {posargs} -vv tests/functional --profile service_account
 deps =
   -rdev-requirements.txt
   -e.


### PR DESCRIPTION
resolves #

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->

### Description

Configuring the python model tests to execute on Dataproc cluster instead of serverless

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
