### PR TITLE
Backport PR 607 manually to 1.1.latest.

### DIFF
--- a/.changes/unreleased/Fixes-20230315-130504.yaml
+++ b/.changes/unreleased/Fixes-20230315-130504.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix failing test by removing no erroneous asserts.
+time: 2023-03-15T13:05:04.747323-07:00
+custom:
+  Author: versusfacit
+  Issue: "605"

--- a/tests/integration/persist_docs_tests/models-bigquery-nested/schema.yml
+++ b/tests/integration/persist_docs_tests/models-bigquery-nested/schema.yml
@@ -3,17 +3,9 @@ version: 2
 models:
   - name: table_model_nested
     columns:
-      - name: level_1
-        description: level_1 column description
-      - name: level_1.level_2
-        description: level_2 column description
       - name: level_1.level_2.level_3_a
         description: level_3 column description
   - name: view_model_nested
     columns:
-      - name: level_1
-        description: level_1 column description
-      - name: level_1.level_2
-        description: level_2 column description
       - name: level_1.level_2.level_3_a
         description: level_3 column description

--- a/tests/integration/persist_docs_tests/test_persist_docs.py
+++ b/tests/integration/persist_docs_tests/test_persist_docs.py
@@ -138,6 +138,8 @@ class TestPersistDocsNested(BasePersistDocsTest):
         colunmn descriptions are persisted on the test model table and view.
 
         Next, generate the catalog and check if the comments are also included.
+
+        Note: dbt-bigquery does not allow comments on models with children nodes
         """
         self.run_dbt(['seed'])
         self.run_dbt()
@@ -162,25 +164,13 @@ class TestPersistDocsNested(BasePersistDocsTest):
                 bq_schema = client.get_table(table_id).schema
 
                 level_1_field = bq_schema[0]
-                assert level_1_field.description == \
-                       "level_1 column description"
-
                 level_2_field = level_1_field.fields[0]
-                assert level_2_field.description == \
-                       "level_2 column description"
-
                 level_3_field = level_2_field.fields[0]
                 assert level_3_field.description == \
                        "level_3 column description"
 
             # check the descriptions in the catalog
             node = catalog_data['nodes']['model.test.{}'.format(node_id)]
-
-            level_1_column = node['columns']['level_1']
-            assert level_1_column['comment'] == "level_1 column description"
-
-            level_2_column = node['columns']['level_1.level_2']
-            assert level_2_column['comment'] == "level_2 column description"
 
             level_3_column = node['columns']['level_1.level_2.level_3_a']
             assert level_3_column['comment'] == "level_3 column description"


### PR DESCRIPTION
backport #607 

### Description

Manually done because of massive file differences between `main` and this PR which is pre test conversion roundup.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
