### PR TITLE
Fix split part negative part number

### DIFF
--- a/.changes/unreleased/Fixes-20230319-152543.yaml
+++ b/.changes/unreleased/Fixes-20230319-152543.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: update split part to handle negative part numbers
+time: 2023-03-19T15:25:43.430654-05:00
+custom:
+  Author: dave-connors-3
+  Issue: "615"

--- a/dbt/include/bigquery/macros/utils/split_part.sql
+++ b/dbt/include/bigquery/macros/utils/split_part.sql
@@ -13,7 +13,7 @@
           length({{ string_text }})
           - length(
               replace({{ string_text }},  {{ delimiter_text }}, '')
-          ) + 1
+          ) + 1 {{ part_number }}
         )]
   {% endif %}
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 # install latest changes in dbt-core
 # TODO: how to automate switching from develop to version branches?
-git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
-git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-tests-adapter&subdirectory=tests/adapter
+git+https://github.com/dbt-labs/dbt-core.git@negative-arg-split-part#egg=dbt-core&subdirectory=core
+git+https://github.com/dbt-labs/dbt-core.git@negative-arg-split-part#egg=dbt-tests-adapter&subdirectory=tests/adapter
 
 # if version 1.x or greater -> pin to major version
 # if version 0.x -> pin to minor


### PR DESCRIPTION
resolves #615 

### Description

Adds `part_number` to the second calculation when argument is negative to return the correct element from the array. 

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
