### PR TITLE
Use _make_ref_key_dict instead of _make_ref_key_msg

### DIFF
--- a/.changes/unreleased/Fixes-20230322-162200.yaml
+++ b/.changes/unreleased/Fixes-20230322-162200.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Use _make_ref_key_dict instead of _make_ref_key_msg
+time: 2023-03-22T16:22:00.091222-04:00
+custom:
+  Author: gshank
+  Issue: "621"

--- a/dbt/adapters/bigquery/impl.py
+++ b/dbt/adapters/bigquery/impl.py
@@ -18,7 +18,7 @@ from dbt.adapters.base import (
     PythonJobHelper,
 )
 
-from dbt.adapters.cache import _make_ref_key_msg
+from dbt.adapters.cache import _make_ref_key_dict
 
 from dbt.adapters.bigquery.relation import BigQueryRelation
 from dbt.adapters.bigquery.dataset import add_access_entry_to_dataset
@@ -332,7 +332,7 @@ class BigQueryAdapter(BaseAdapter):
         # use SQL 'create schema'
         relation = relation.without_identifier()  # type: ignore
 
-        fire_event(SchemaCreation(relation=_make_ref_key_msg(relation)))
+        fire_event(SchemaCreation(relation=_make_ref_key_dict(relation)))
         kwargs = {
             "relation": relation,
         }
@@ -346,7 +346,7 @@ class BigQueryAdapter(BaseAdapter):
         database = relation.database
         schema = relation.schema
         logger.debug('Dropping schema "{}.{}".', database, schema)  # in lieu of SQL
-        fire_event(SchemaDrop(relation=_make_ref_key_msg(relation)))
+        fire_event(SchemaDrop(relation=_make_ref_key_dict(relation)))
         self.connections.drop_dataset(database, schema)
         self.cache.drop_schema(database, schema)
 


### PR DESCRIPTION
resolves #621


### Description

The dbt Core switch to Google protobuf changed the name of a function from `_make_ref_key_msg` to `_make_ref_key_dict`.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
