### PR TITLE
Enable single-line `private_key` for BigQuery Service Account JSON Authentication

### DIFF
--- a/.changes/unreleased/Fixes-20230322-150627.yaml
+++ b/.changes/unreleased/Fixes-20230322-150627.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Enable single-line `private_key` for BigQuery Service Account JSON Authentication
+time: 2023-03-22T15:06:27.761416-06:00
+custom:
+  Author: dbeatty10
+  Issue: "7164"

--- a/dbt/adapters/bigquery/connections.py
+++ b/dbt/adapters/bigquery/connections.py
@@ -309,6 +309,8 @@ class BigQueryConnectionManager(BaseConnectionManager):
 
         elif method == BigQueryConnectionMethod.SERVICE_ACCOUNT_JSON:
             details = profile_credentials.keyfile_json
+            private_key = details.get("private_key", "").replace("\\n", "\n")
+            details["private_key"] = private_key
             return creds.from_service_account_info(details, scopes=profile_credentials.scopes)
 
         elif method == BigQueryConnectionMethod.OAUTH_SECRETS:


### PR DESCRIPTION
resolves #624

### Description

Suppose a user has two different environment variables and the only difference is that one has a multi-line value and the other is a single-line value (with `\n` instead of newlines):

`BQ_PRIVATE_KEY_MULTI_LINE`
```
-----BEGIN PRIVATE KEY-----
xxxx
-----END PRIVATE KEY-----
```

`BQ_PRIVATE_KEY_SINGLE_LINE`
```
-----BEGIN PRIVATE KEY-----\nxxxx\n-----END PRIVATE KEY-----\n
```

Ideally, they should be able to do either of the following when using [Service Account JSON](https://docs.getdbt.com/reference/warehouse-setups/bigquery-setup#service-account-json) Authentication Methods for BigQuery:
```yaml
        private_key: "{{ env_var('BQ_PRIVATE_KEY_MULTI_LINE') }}"
```
or:
```yaml
        private_key: "{{ env_var('BQ_PRIVATE_KEY_SINGLE_LINE') }}"
```

Currently, the former works, but the latter doesn't. This PR makes it so that both will work.

### Current workaround

@yingyingqiqi shared the following workaround [here](https://github.com/dbt-labs/dbt-core/issues/3044#issuecomment-1469147109) and [here](https://github.com/dbt-labs/dbt-bigquery/issues/624):
```yaml
        private_key: "{{ env_var('BIGQUERY_KEYFILE_JSON_PRIVATE_KEY').split('\\\\n') | join('\n') }}"
```

### Exporting single or multi-line environment variables

Assuming [`jq`](https://stedolan.github.io/jq/download/) is installed...

Extract the `private_key` from a BQ service key into an environment variable with a multi-line value:
```shell
export BQ_PRIVATE_KEY_MULTI_LINE=$(jq -r ".private_key" /full/path/to/bigquery-service-key.json)
```

Extract the `private_key` from a BQ service key into an environment variable with a single-line value (from  https://github.com/stedolan/jq/issues/1881#issuecomment-479518797):
```shell
export BQ_PRIVATE_KEY_SINGLE_LINE=$(jq ".private_key" /full/path/to/bigquery-service-key.json | sed -e "s/^\"//g" -e "s/\"$//g")
```

### Visually confirm if an environment variable is single-line or multi-line

```shell
printf "%s" "$BQ_PRIVATE_KEY_SINGLE_LINE"
printf "%s" "$BQ_PRIVATE_KEY_MULTI_LINE"
```

### Tested variants

Any of the following should work although the first two are the ones we really care about (with the last ones just for backwards-compatibility with the current workaround and the middle ones for kicks):
```yaml
        private_key: "{{ env_var('BQ_PRIVATE_KEY_SINGLE_LINE') }}"
        private_key: "{{ env_var('BQ_PRIVATE_KEY_MULTI_LINE') }}"
        private_key: "{{ env_var('BQ_PRIVATE_KEY_SINGLE_LINE').split('\n') | join('\n') }}"
        private_key: "{{ env_var('BQ_PRIVATE_KEY_MULTI_LINE').split('\n') | join('\n') }}"
        private_key: "{{ env_var('BQ_PRIVATE_KEY_SINGLE_LINE').split('\\n') | join('\n') }}"
        private_key: "{{ env_var('BQ_PRIVATE_KEY_MULTI_LINE').split('\\n') | join('\n') }}"
        private_key: "{{ env_var('BQ_PRIVATE_KEY_SINGLE_LINE').split('\\\\n') | join('\n') }}"
        private_key: "{{ env_var('BQ_PRIVATE_KEY_MULTI_LINE').split('\\\\n') | join('\n') }}"
``` 

### Example profiles.yml

```yml
sandcastle-bigquery:
  target: dev
  outputs:
    dev:
      type: bigquery
      location: US
      project: "{{ env_var('BIGQUERY_PROJECT') }}"
      dataset: "{{ env_var('BIGQUERY_DATASET') }}"
      threads: 1

      # These fields come from the service account json keyfile
      method: service-account-json
      keyfile_json:
        type: "{{ env_var('BIGQUERY_KEYFILE_JSON_TYPE') }}"
        project_id: "{{ env_var('BIGQUERY_KEYFILE_JSON_PROJECT_ID') }}"
        private_key_id: "{{ env_var('BIGQUERY_KEYFILE_JSON_PRIVATE_KEY_ID') }}"
        client_email: "{{ env_var('BIGQUERY_KEYFILE_JSON_CLIENT_EMAIL') }}"
        private_key: "{{ env_var('BQ_PRIVATE_KEY_SINGLE_LINE') }}"
        # private_key: "{{ env_var('BQ_PRIVATE_KEY_MULTI_LINE') }}"
        client_id: "{{ env_var('BIGQUERY_KEYFILE_JSON_CLIENT_ID') }}"
        auth_uri: "{{ env_var('BIGQUERY_KEYFILE_JSON_AUTH_URI') }}"
        token_uri: "{{ env_var('BIGQUERY_KEYFILE_JSON_TOKEN_URI') }}"
        auth_provider_x509_cert_url: "{{ env_var('BIGQUERY_KEYFILE_JSON_AUTH_PROVIDER_X509_CERT_URL') }}"
        client_x509_cert_url: "{{ env_var('BIGQUERY_KEYFILE_JSON_CLIENT_X509_CERT_URL') }}"
```

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)