### PR TITLE
Remove unnecessary test for get_relation

### DIFF
--- a/tests/unit/test_bigquery_adapter.py
+++ b/tests/unit/test_bigquery_adapter.py
@@ -395,6 +395,7 @@ class TestConnectionNamePassthrough(BaseTestBigQueryAdapter):
         self.relation_cls = self._relation_patch.start()
 
         self.mock_connection_manager = self.conn_manager_cls.return_value
+        self.mock_connection_manager.get_if_exists().name = "mock_conn_name"
         self.conn_manager_cls.TYPE = "bigquery"
         self.relation_cls.get_default_quote_policy.side_effect = (
             BigQueryRelation.get_default_quote_policy


### PR DESCRIPTION

### Description

dbt Core changed to use google protobuf, which doesn't allow incorrectly typed values for logging events, such as the MagicMock conn_name.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
