### PR TITLE
Use tmp table in static insert overwrite

### DIFF
--- a/.changes/unreleased/Fixes-20230325-204352.yaml
+++ b/.changes/unreleased/Fixes-20230325-204352.yaml
@@ -3,4 +3,4 @@ body: Use tmp table in static insert overwrite to avoid computing the SQL twice
 time: 2023-03-25T20:43:52.830135+01:00
 custom:
   Author: Kayrnt
-  Issue: "427"
+  Issue: 427 556

--- a/.changes/unreleased/Fixes-20230325-204352.yaml
+++ b/.changes/unreleased/Fixes-20230325-204352.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Use tmp table in static insert overwrite to avoid computing the SQL twice
+time: 2023-03-25T20:43:52.830135+01:00
+custom:
+  Author: Kayrnt
+  Issue: "427"

--- a/dbt/include/bigquery/macros/materializations/incremental_strategy/insert_overwrite.sql
+++ b/dbt/include/bigquery/macros/materializations/incremental_strategy/insert_overwrite.sql
@@ -1,5 +1,5 @@
 {% macro bq_generate_incremental_insert_overwrite_build_sql(
-    tmp_relation, target_relation, sql, unique_key, partition_by, partitions, dest_columns, on_schema_change, copy_partitions
+    tmp_relation, target_relation, sql, unique_key, partition_by, partitions, dest_columns, tmp_relation_exists, copy_partitions
 ) %}
     {% if partition_by is none %}
       {% set missing_partition_msg -%}
@@ -9,7 +9,7 @@
     {% endif %}
 
     {% set build_sql = bq_insert_overwrite_sql(
-        tmp_relation, target_relation, sql, unique_key, partition_by, partitions, dest_columns, on_schema_change, copy_partitions
+        tmp_relation, target_relation, sql, unique_key, partition_by, partitions, dest_columns, tmp_relation_exists, copy_partitions
     ) %}
 
     {{ return(build_sql) }}
@@ -39,14 +39,14 @@
     tmp_relation, target_relation, sql, unique_key, partition_by, partitions, dest_columns, tmp_relation_exists, copy_partitions
 ) %}
   {% if partitions is not none and partitions != [] %} {# static #}
-      {{ bq_static_insert_overwrite_sql(tmp_relation, target_relation, sql, partition_by, partitions, dest_columns, copy_partitions) }}
+      {{ bq_static_insert_overwrite_sql(tmp_relation, target_relation, sql, partition_by, partitions, dest_columns, tmp_relation_exists, copy_partitions) }}
   {% else %} {# dynamic #}
       {{ bq_dynamic_insert_overwrite_sql(tmp_relation, target_relation, sql, unique_key, partition_by, dest_columns, tmp_relation_exists, copy_partitions) }}
   {% endif %}
 {% endmacro %}
 
 {% macro bq_static_insert_overwrite_sql(
-    tmp_relation, target_relation, sql, partition_by, partitions, dest_columns, copy_partitions
+    tmp_relation, target_relation, sql, partition_by, partitions, dest_columns, tmp_relation_exists, copy_partitions
 ) %}
 
       {% set predicate -%}
@@ -57,10 +57,16 @@
 
       {%- set source_sql -%}
         (
-          {%- if partition_by.time_ingestion_partitioning -%}
-          {{ wrap_with_time_ingestion_partitioning_sql(partition_by, sql, True) }}
+          {%- if tmp_relation_exists -%}
+            select
+            {% if partition_by.time_ingestion_partitioning -%}
+             {{ partition_by.insertable_time_partitioning_field() }},
+            {%- endif -%}
+            * from {{ tmp_relation }}
+          {%- elif partition_by.time_ingestion_partitioning -%}
+            {{ wrap_with_time_ingestion_partitioning_sql(partition_by, sql, True) }}
           {%- else -%}
-          {{sql}}
+            {{sql}}
           {%- endif -%}
         )
       {%- endset -%}
@@ -69,13 +75,19 @@
           {% do bq_copy_partitions(tmp_relation, target_relation, partitions, partition_by) %}
       {% else %}
 
-      {#-- Because we're putting the model SQL _directly_ into the MERGE statement,
+      {#-- In case we're putting the model SQL _directly_ into the MERGE statement,
          we need to prepend the MERGE statement with the user-configured sql_header,
          which may be needed to resolve that model SQL (e.g. referencing a variable or UDF in the header)
-         in the "dynamic" case, we save the model SQL result as a temp table first, wherein the
+         in the "temporary table exists" case, we save the model SQL result as a temp table first, wherein the
          sql_header is included by the create_table_as macro.
       #}
-      {{ get_insert_overwrite_merge_sql(target_relation, source_sql, dest_columns, [predicate], include_sql_header=true) }}
+      -- 1. run the merge statement
+      {{ get_insert_overwrite_merge_sql(target_relation, source_sql, dest_columns, [predicate], include_sql_header = not tmp_relation_exists) }}
+
+      {%- if tmp_relation_exists -%}
+      -- 2. clean up the temp table
+      drop table if exists {{ tmp_relation }}
+      {%- endif -%}
 
   {% endif %}
 {% endmacro %}

--- a/dbt/include/bigquery/macros/materializations/incremental_strategy/insert_overwrite.sql
+++ b/dbt/include/bigquery/macros/materializations/incremental_strategy/insert_overwrite.sql
@@ -57,17 +57,19 @@
 
       {%- set source_sql -%}
         (
-          {%- if tmp_relation_exists -%}
+          {% if partition_by.time_ingestion_partitioning and tmp_relation_exists -%}
+          select
+            {{ partition_by.insertable_time_partitioning_field() }},
+            * from {{ tmp_relation }}
+          {% elif tmp_relation_exists -%}
             select
-            {% if partition_by.time_ingestion_partitioning -%}
-             {{ partition_by.insertable_time_partitioning_field() }},
-            {%- endif -%}
             * from {{ tmp_relation }}
           {%- elif partition_by.time_ingestion_partitioning -%}
             {{ wrap_with_time_ingestion_partitioning_sql(partition_by, sql, True) }}
           {%- else -%}
             {{sql}}
           {%- endif -%}
+
         )
       {%- endset -%}
 
@@ -82,11 +84,11 @@
          sql_header is included by the create_table_as macro.
       #}
       -- 1. run the merge statement
-      {{ get_insert_overwrite_merge_sql(target_relation, source_sql, dest_columns, [predicate], include_sql_header = not tmp_relation_exists) }}
+      {{ get_insert_overwrite_merge_sql(target_relation, source_sql, dest_columns, [predicate], include_sql_header = not tmp_relation_exists) }};
 
       {%- if tmp_relation_exists -%}
       -- 2. clean up the temp table
-      drop table if exists {{ tmp_relation }}
+      drop table if exists {{ tmp_relation }};
       {%- endif -%}
 
   {% endif %}

--- a/tests/functional/adapter/incremental/test_incremental_strategies.py
+++ b/tests/functional/adapter/incremental/test_incremental_strategies.py
@@ -25,6 +25,7 @@ from tests.functional.adapter.incremental.incremental_strategy_fixtures import (
     overwrite_time_sql,
     overwrite_day_with_time_ingestion_sql,
     overwrite_day_with_time_partition_datetime_sql,
+    overwrite_static_day_sql,
 )
 
 
@@ -46,6 +47,7 @@ class TestBigQueryScripting(SeedConfigBase):
             "incremental_overwrite_time.sql": overwrite_time_sql,
             "incremental_overwrite_day_with_time_partition.sql": overwrite_day_with_time_ingestion_sql,
             "incremental_overwrite_day_with_time_partition_datetime.sql": overwrite_day_with_time_partition_datetime_sql,
+            "incremental_overwrite_static_day.sql": overwrite_static_day_sql,
         }
 
     @pytest.fixture(scope="class")
@@ -63,10 +65,10 @@ class TestBigQueryScripting(SeedConfigBase):
     def test__bigquery_assert_incremental_configurations_apply_the_right_strategy(self, project):
         run_dbt(["seed"])
         results = run_dbt()
-        assert len(results) == 10
+        assert len(results) == 11
 
         results = run_dbt()
-        assert len(results) == 10
+        assert len(results) == 11
         incremental_strategies = [
             ("incremental_merge_range", "merge_expected"),
             ("incremental_merge_time", "merge_expected"),
@@ -79,6 +81,7 @@ class TestBigQueryScripting(SeedConfigBase):
                 "incremental_overwrite_day_with_time_partition_datetime",
                 "incremental_overwrite_day_with_time_partition_expected",
             ),
+            ("incremental_overwrite_static_day", "incremental_overwrite_day_expected"),
         ]
         db_with_schema = f"{project.database}.{project.test_schema}"
         for incremental_strategy in incremental_strategies:


### PR DESCRIPTION
Resolves #427
Resolves #556

### Description

As described in #427, static insert overwrite, when involving `on_schema_change != 'ignore'` would create a temp table to check for a schema change anyway.
It fixes as well:
- In case, `on_schema_change = 'ignore'` with dynamic insert overwrite where the SQL header would not be added
- In case, we would have static insert overwrite with `on_schema_change != 'ignore'` where the temp table would not be deleted

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
