### PR TITLE
Fix polling timeout

### DIFF
--- a/.changes/unreleased/Fixes-20230329-155716.yaml
+++ b/.changes/unreleased/Fixes-20230329-155716.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix passing execution timeout to Dataproc result polling.
+time: 2023-03-29T15:57:16.290828-04:00
+custom:
+  Author: atvaccaro
+  Issue: "577"

--- a/dbt/adapters/bigquery/python_submissions.py
+++ b/dbt/adapters/bigquery/python_submissions.py
@@ -3,12 +3,9 @@ from typing import Dict, Union
 from dbt.adapters.base import PythonJobHelper
 from dbt.adapters.bigquery import BigQueryConnectionManager, BigQueryCredentials
 from dbt.adapters.bigquery.connections import DataprocBatchConfig
-from google.api_core import retry
 from google.api_core.client_options import ClientOptions
 from google.cloud import storage, dataproc_v1  # type: ignore
 from google.protobuf.json_format import ParseDict
-
-OPERATION_RETRY_TIME = 10
 
 
 class BaseDataProcHelper(PythonJobHelper):
@@ -43,7 +40,6 @@ class BaseDataProcHelper(PythonJobHelper):
         self.timeout = self.parsed_model["config"].get(
             "timeout", self.credential.job_execution_timeout_seconds or 60 * 60 * 24
         )
-        self.retry = retry.Retry(maximum=10.0, deadline=self.timeout)
         self.client_options = ClientOptions(
             api_endpoint="{}-dataproc.googleapis.com:443".format(self.credential.dataproc_region)
         )
@@ -98,7 +94,7 @@ class ClusterDataprocHelper(BaseDataProcHelper):
                 "job": job,
             }
         )
-        response = operation.result(retry=self.retry)
+        response = operation.result(timeout=self.timeout)
         # check if job failed
         if response.status.state == 6:
             raise ValueError(response.status.details)
@@ -123,7 +119,7 @@ class ServerlessDataProcHelper(BaseDataProcHelper):
         operation = self.job_client.create_batch(request=request)  # type: ignore
         # this takes quite a while, waiting on GCP response to resolve
         # (not a google-api-core issue, more likely a dataproc serverless issue)
-        response = operation.result(retry=self.retry)
+        response = operation.result(timeout=self.timeout)
         return response
         # there might be useful results here that we can parse and return
         # Dataproc job output is saved to the Cloud Storage bucket


### PR DESCRIPTION
resolves #577 

### Description

Applies dbt's execution timeout concept as a simple `timeout` rather than the existing per-RPC `retry`. The rest of the defaults seem reasonable.

Question: is 24 hours still a sane default? If so, I'll make it a constant. Also, I'm wondering if perhaps we should catch the polling timeout and attempt to cancel the submitted batch?

I'm unsure what I should do about tests since the existing Dataproc tests seem disabled. Backporting this to 1.3/1.4 would be super helpful. 

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
