### PR TITLE
add steps to drop existing tables on --full-refresh

### DIFF
--- a/.changes/unreleased/Fixes-20230408-035117.yaml
+++ b/.changes/unreleased/Fixes-20230408-035117.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: ' add full refresh capabilities to tabular bigquery python models to accommodate
+  schema changes'
+time: 2023-04-08T03:51:17.167349-07:00
+custom:
+  Author: versusfacit
+  Issue: "653"

--- a/dbt/include/bigquery/macros/adapters.sql
+++ b/dbt/include/bigquery/macros/adapters.sql
@@ -73,6 +73,12 @@
     TODO: Deep dive into spark sessions to see if we can reuse a single session for an entire
     dbt invocation.
      --#}
+
+    {#-- when a user wants to change the schema of a relation, first drop the table in the big query dataset --#}
+    {%- set old_relation = adapter.get_relation(database=relation.database, schema=relation.schema, identifier=relation.identifier) -%}
+    {%- if (old_relation.is_table and (should_full_refresh())) -%}
+      {% do adapter.drop_relation(relation) %}
+    {%- endif -%}
     {{ py_write_table(compiled_code=compiled_code, target_relation=relation.quote(database=False, schema=False, identifier=False)) }}
   {%- else -%}
     {% do exceptions.raise_compiler_error("bigquery__create_table_as macro didn't get supported language, it got %s" % language) %}

--- a/dbt/include/bigquery/macros/adapters.sql
+++ b/dbt/include/bigquery/macros/adapters.sql
@@ -74,7 +74,7 @@
     dbt invocation.
      --#}
 
-    {#-- when a user wants to change the schema of a relation, first drop the table in the big query dataset --#}
+    {#-- when a user wants to change the schema of an existing relation, they must intentionally drop the table in the dataset --#}
     {%- set old_relation = adapter.get_relation(database=relation.database, schema=relation.schema, identifier=relation.identifier) -%}
     {%- if (old_relation.is_table and (should_full_refresh())) -%}
       {% do adapter.drop_relation(relation) %}


### PR DESCRIPTION
resolves #609 


### Description

I'm confident I've got a working fix here; a little less confident on user experience. 

This is also my first time working with all of these systems involved with python models; interesting stuff. Lots of surface area to find a small fix.

#### 1. the root of the problem
When schema changes are performed inside a model and the target relation already exists (albeit in a now out-of-date form), the bigquery spark overwrite strategy fails ([I checked, there are no built-in alternatives](https://spark.apache.org/docs/1.4.0/api/java/org/apache/spark/sql/SaveMode.html)). 

#### 2. my proposed solution
Therefore, a step is needed to clear out any existing, corresponding target relation before attempting to build a model. I first attempted to do this inside of the Python model, but that only clears the model in the spark namespace. We must pre-clear the model *only* in the SQL namespace. 

#### 3. one open question
@Fleid: I predict midflight schema changes are going to occur when a user is intentionally changing the definition of a model, which I don't think would be an everyday occurrence. We can therefore confine this behavior to the `--full-refresh` flag which empowers the user to decide when to invoke this behavior. This is only needed in this schema change scenario because of a quirk of `save`, a dataframe function. 

I don't love the idea of overloading this flag further, but I also think it is relatively intuitive and better to make this opt in; can't think of a better differentiator. Plus, we already say in [docs](https://docs.getdbt.com/reference/resource-configs/full_refresh) that models generically are affected by this flag.

Do you let me know if you think we should pursue a different user experience

### Testing regiment

```py 
import pandas
def model(dbt, spark):
    dbt.config(
        materialized='table',
    )
    data = [[1,2]] * 10
    return spark.createDataFrame(data, schema=['test', 'test2'])
```
First, run this. Second, change the model to this:
```py
import pandas
def model(dbt, spark):
    dbt.config(
        materialized='table',
    )
    data = [[1,2]] * 10
    return spark.createDataFrame(data, schema=['test1', 'test3'])
```
When you re-run this without `--full-refresh` or my changes, the error discussed in the issue would be triggered. Here's an example:

<img width="811" alt="image" src="https://user-images.githubusercontent.com/67295367/230716923-b81c622e-77d7-4e65-8842-a5741e312eb3.png">

<img width="811" alt="image" src="https://user-images.githubusercontent.com/67295367/230716700-58b3e096-2ccb-4c22-9266-c463cecad89b.png">

But with the new behavior of `dbt run -m <py model> --full-refresh`, things look good.

<img width="1033" alt="image" src="https://user-images.githubusercontent.com/67295367/230716950-28d1c488-10c6-4607-98db-1eda3298e0e3.png">

<img width="811" alt="image" src="https://user-images.githubusercontent.com/67295367/230716889-15f06df6-bd16-4dc4-983c-c406c15e75df.png">

<img width="271" alt="image" src="https://user-images.githubusercontent.com/67295367/230716992-36731e68-c39b-4ad3-900f-bd17e0a8e0ca.png">


### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)