### PR TITLE
Update `bigquery__format_column` per dbt-core#7319

### DIFF
--- a/.changes/unreleased/Under the Hood-20230411-143129.yaml
+++ b/.changes/unreleased/Under the Hood-20230411-143129.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Update bigquery__format_column macro to support prettier ContractError message"
+time: 2023-04-11T14:31:29.378726+02:00
+custom:
+  Author: jtcohen6
+  Issue: "656"

--- a/dbt/include/bigquery/macros/utils/get_columns_spec_ddl.sql
+++ b/dbt/include/bigquery/macros/utils/get_columns_spec_ddl.sql
@@ -27,5 +27,7 @@
 {% endmacro %}
 
 {% macro bigquery__format_column(column) -%}
-  {{ return(column.column.lower() ~ " " ~ column.data_type) }}
+  {% set data_type = column.data_type %}
+  {% set formatted = column.column.lower() ~ " " ~ data_type %}
+  {{ return({'name': column.name, 'data_type': data_type, 'formatted': formatted}) }}
 {%- endmacro -%}

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 # install latest changes in dbt-core
 # TODO: how to automate switching from develop to version branches?
-git+https://github.com/dbt-labs/dbt-core.git@jerco/rebase-7223-contract-error-message#egg=dbt-core&subdirectory=core
-git+https://github.com/dbt-labs/dbt-core.git@jerco/rebase-7223-contract-error-message#egg=dbt-tests-adapter&subdirectory=tests/adapter
+git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
+git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-tests-adapter&subdirectory=tests/adapter
 
 # if version 1.x or greater -> pin to major version
 # if version 0.x -> pin to minor

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 # install latest changes in dbt-core
 # TODO: how to automate switching from develop to version branches?
-git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
-git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-tests-adapter&subdirectory=tests/adapter
+git+https://github.com/dbt-labs/dbt-core.git@jerco/rebase-7223-contract-error-message#egg=dbt-core&subdirectory=core
+git+https://github.com/dbt-labs/dbt-core.git@jerco/rebase-7223-contract-error-message#egg=dbt-tests-adapter&subdirectory=tests/adapter
 
 # if version 1.x or greater -> pin to major version
 # if version 0.x -> pin to minor


### PR DESCRIPTION
resolves #656

Updates `bigquery__format_column` per change in https://github.com/dbt-labs/dbt-core/pull/7319/commits/100afd1856b1c69420825f9f9db186bfda041ec8.

This macro is brand-new in v1.5, so this isn't a breaking change for any existing users.