### PR TITLE
[ADAP-492] Support partition_by and cluster_by on python models (#680)

### DIFF
--- a/.changes/unreleased/Features-20230426-152526.yaml
+++ b/.changes/unreleased/Features-20230426-152526.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: Support partition_by and cluster_by on python models when supplied in model
+  configurations
+time: 2023-04-26T15:25:26.285021+09:00
+custom:
+  Author: kalanyuz
+  Issue: "680"

--- a/dbt/include/bigquery/macros/materializations/table.sql
+++ b/dbt/include/bigquery/macros/materializations/table.sql
@@ -113,7 +113,7 @@ df.write \
   {%- if partition_config.data_type | lower in ('date','timestamp','datetime') %}
   .option("partitionField", "{{- partition_config.field -}}") \
   {%- if partition_config.granularity is not none %}
-  .option("partitonType", "{{- partition_config.granularity -}}") \
+  .option("partitionType", "{{- partition_config.granularity -}}") \
   {%- endif %}
   {%- endif %}
   {%- if raw_cluster_by is not none %}

--- a/dbt/include/bigquery/macros/materializations/table.sql
+++ b/dbt/include/bigquery/macros/materializations/table.sql
@@ -45,11 +45,11 @@
 
 {% endmaterialization %}
 
--- TODO dataproc requires a temp bucket to perform BQ write
--- this is hard coded to internal testing ATM. need to adjust to render
--- or find another way around
 {% macro py_write_table(compiled_code, target_relation) %}
 from pyspark.sql import SparkSession
+{%- set raw_partition_by = config.get('partition_by', none) -%}
+{%- set raw_cluster_by = config.get('cluster_by', none) -%}
+{%- set partition_config = adapter.parse_partition_by(raw_partition_by) %}
 
 spark = SparkSession.builder.appName('smallTest').getOrCreate()
 
@@ -109,6 +109,15 @@ else:
 df.write \
   .mode("overwrite") \
   .format("bigquery") \
-  .option("writeMethod", "direct").option("writeDisposition", 'WRITE_TRUNCATE') \
+  .option("writeMethod", "indirect").option("writeDisposition", 'WRITE_TRUNCATE') \
+  {%- if partition_config.data_type | lower in ('date','timestamp','datetime') %}
+  .option("partitionField", "{{- partition_config.field -}}") \
+  {%- if partition_config.granularity is not none %}
+  .option("partitonType", "{{- partition_config.granularity -}}") \
+  {%- endif %}
+  {%- endif %}
+  {%- if raw_cluster_by is not none %}
+  .option("clusteredFields", "{{- raw_cluster_by|join(',') -}}") \
+  {%- endif %}
   .save("{{target_relation}}")
 {% endmacro %}

--- a/tests/functional/adapter/test_python_model.py
+++ b/tests/functional/adapter/test_python_model.py
@@ -125,6 +125,7 @@ models:
         description: Column C
 """
 
+
 class TestPythonPartitionedModels:
     @pytest.fixture(scope="class")
     def macros(self):
@@ -138,7 +139,7 @@ class TestPythonPartitionedModels:
         }
 
     def test_multiple_named_python_models(self, project):
-        result= run_dbt(["run"])
+        result = run_dbt(["run"])
         assert len(result) == 1
 
         test_results = run_dbt(["test"])

--- a/tests/functional/adapter/test_python_model.py
+++ b/tests/functional/adapter/test_python_model.py
@@ -54,6 +54,100 @@ def model(dbt, spark):
     return spark.createDataFrame(data, schema=['test', 'test2'])
 """
 
+macro__partition_count_sql = """
+{% test number_partitions(model, expected) %}
+
+    {%- set result = get_partitions_metadata(model) %}
+
+    {% if result %}
+        {% set partitions = result.columns['partition_id'].values() %}
+    {% else %}
+        {% set partitions = () %}
+    {% endif %}
+
+    {% set actual = partitions | length %}
+    {% set success = 1 if model and actual == expected else 0 %}
+
+    select 'Expected {{ expected }}, but got {{ actual }}' as validation_error
+    from (select true)
+    where {{ success }} = 0
+
+{% endtest %}
+"""
+
+models__partitioned_model_python = """
+import pandas as pd
+
+def model(dbt, spark):
+    dbt.config(
+        materialized='table',
+        partition_by={
+                "field": "C",
+                "data_type": "timestamp",
+                "granularity": "day",
+            },
+        cluster_by=["A"],
+    )
+    random_array = [
+        ["A", -157.9871329592354],
+        ["B", -528.9769041860632],
+        ["B", 941.0504221837489],
+        ["B", 919.5903586746183],
+        ["A", -121.25678519054622],
+        ["A", 254.9985130814921],
+        ["A", 833.2963094260072],
+    ]
+
+    df = pd.DataFrame(random_array, columns=["A", "B"])
+
+    df["C"] = pd.to_datetime('now')
+
+    final_df = df[["A", "B", "C"]]
+
+    return final_df
+"""
+
+models__partitioned_model_yaml = """
+models:
+  - name: python_partitioned_model
+    description: A random table with a calculated column defined in python.
+    config:
+      batch_id: '{{ run_started_at.strftime("%Y-%m-%d-%H-%M-%S") }}-python-partitioned'
+    tests:
+      - number_partitions:
+          expected: "{{ var('expected', 1) }}"
+    columns:
+      - name: A
+        description: Column A
+      - name: B
+        description: Column B
+      - name: C
+        description: Column C
+"""
+
+class TestPythonPartitionedModels:
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {"partition_metadata.sql": macro__partition_count_sql}
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "python_partitioned_model.py": models__partitioned_model_python,
+            "python_partitioned_model.yml": models__partitioned_model_yaml,
+        }
+
+    def test_multiple_named_python_models(self, project):
+        result= run_dbt(["run"])
+        assert len(result) == 1
+
+        test_results = run_dbt(["test"])
+        for result in test_results:
+            assert result.status == "pass"
+            assert not result.skipped
+            assert result.failures == 0
+
+
 models__simple_python_model_v2 = """
 import pandas
 


### PR DESCRIPTION
resolves #680

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->

### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

Currently, Python models do not support table creation with partition_by and cluster_by when supplied to the model configuration, despite the spark-bigquery-connector having support for it with [indirect save mode](https://github.com/GoogleCloudDataproc/spark-bigquery-connector#writing-data-to-bigquery).

For more details, see #680

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
