### PR TITLE
Fix UDF usage with time ingestion

### DIFF
--- a/.changes/unreleased/Fixes-20230427-141957.yaml
+++ b/.changes/unreleased/Fixes-20230427-141957.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: 'Fix UDF usage with time ingestion'
+time: 2023-04-27T14:19:57.518037+02:00
+custom:
+  Author: Kayrnt
+  Issue: "684"

--- a/dbt/include/bigquery/macros/materializations/incremental_strategy/time_ingestion_tables.sql
+++ b/dbt/include/bigquery/macros/materializations/incremental_strategy/time_ingestion_tables.sql
@@ -24,6 +24,8 @@
 {%- endmacro -%}
 
 {% macro bq_insert_into_ingestion_time_partitioned_table_sql(target_relation, sql) -%}
+  {%- set sql_header = config.get('sql_header', none) -%}
+  {{ sql_header if sql_header is not none }}
   {%- set raw_partition_by = config.get('partition_by', none) -%}
   {%- set partition_by = adapter.parse_partition_by(raw_partition_by) -%}
   {% set dest_columns = adapter.get_columns_in_relation(target_relation) %}
@@ -36,6 +38,8 @@
 
 {% macro get_columns_with_types_in_query_sql(select_sql) %}
   {% set sql %}
+    {%- set sql_header = config.get('sql_header', none) -%}
+    {{ sql_header if sql_header is not none }}
     select * from (
       {{ select_sql }}
     ) as __dbt_sbq

--- a/tests/functional/adapter/incremental/incremental_strategy_fixtures.py
+++ b/tests/functional/adapter/incremental/incremental_strategy_fixtures.py
@@ -416,21 +416,27 @@ overwrite_day_with_time_ingestion_sql = """
 }}
 
 
+{%- call set_sql_header(config) %}
+ CREATE TEMP FUNCTION asDateTime(date STRING) AS (
+   cast(date as datetime)
+ );
+{%- endcall %}
+
 with data as (
 
     {% if not is_incremental() %}
 
-        select 1 as id, cast('2020-01-01' as datetime) as date_time union all
-        select 2 as id, cast('2020-01-01' as datetime) as date_time union all
-        select 3 as id, cast('2020-01-01' as datetime) as date_time union all
-        select 4 as id, cast('2020-01-01' as datetime) as date_time
+        select 1 as id, asDateTime('2020-01-01') as date_time union all
+        select 2 as id, asDateTime('2020-01-01') as date_time union all
+        select 3 as id, asDateTime('2020-01-01') as date_time union all
+        select 4 as id, asDateTime('2020-01-01') as date_time
 
     {% else %}
 
         -- we want to overwrite the 4 records in the 2020-01-01 partition
         -- with the 2 records below, but add two more in the 2020-01-02 partition
-        select 10 as id, cast('2020-01-01' as datetime) as date_time union all
-        select 20 as id, cast('2020-01-01' as datetime) as date_time union all
+        select 10 as id, asDateTime('2020-01-01') as date_time union all
+        select 20 as id, asDateTime('2020-01-01') as date_time union all
         select 30 as id, cast('2020-01-02' as datetime) as date_time union all
         select 40 as id, cast('2020-01-02' as datetime) as date_time
 


### PR DESCRIPTION
resolves #684

### Description

When including UDF with BigQuery, those needs to be wrapped in the `sql_header` as the syntax prevents them to be inlined anywhere in the code. Therefore, like [default implementation](https://github.com/dbt-labs/dbt-core/blob/d2f963e20ea945355db57ff3d34a318429a8bf1e/core/dbt/include/global_project/macros/materializations/models/table/create_table_as.sql#L21), we have to include them in the materialization specific macros.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
