### PR TITLE
Fixes adding policy tags when a struct is defined in the yml

### DIFF
--- a/.changes/unreleased/Fixes-20230428-232904.yaml
+++ b/.changes/unreleased/Fixes-20230428-232904.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fixes adding policy tags when a struct is defined in the yml
+time: 2023-04-28T23:29:04.08966+01:00
+custom:
+  Author: dgren161
+  Issue: "687"

--- a/.changes/unreleased/Fixes-20230428-232904.yaml
+++ b/.changes/unreleased/Fixes-20230428-232904.yaml
@@ -2,5 +2,5 @@ kind: Fixes
 body: Fixes adding policy tags when a struct is defined in the yml
 time: 2023-04-28T23:29:04.08966+01:00
 custom:
-  Author: dgren161
+  Author: dgreen161
   Issue: "687"

--- a/dbt/adapters/bigquery/impl.py
+++ b/dbt/adapters/bigquery/impl.py
@@ -693,7 +693,8 @@ class BigQueryAdapter(BaseAdapter):
         if dotted_column_name in dbt_columns:
             column_config = dbt_columns[dotted_column_name]
             bq_column_dict["description"] = column_config.get("description")
-            bq_column_dict["policyTags"] = {"names": column_config.get("policy_tags", list())}
+            if bq_column_dict["type"] != "RECORD":
+                bq_column_dict["policyTags"] = {"names": column_config.get("policy_tags", list())}
 
         new_fields = []
         for child_col_dict in bq_column_dict.get("fields", list()):

--- a/tests/functional/test_delete_column_policy.py
+++ b/tests/functional/test_delete_column_policy.py
@@ -11,7 +11,9 @@ _POLICY_TAG_MODEL = """{{
 }}
 
 select
-  1 field
+  struct(
+    1 as field
+  ) as first_struct
 """
 
 _POLICY_TAG_YML = """version: 2
@@ -19,7 +21,8 @@ _POLICY_TAG_YML = """version: 2
 models:
 - name: policy_tag_table
   columns:
-  - name: field
+  - name: first_struct
+  - name: first_struct.field
     policy_tags:
       - '{{ var("policy_tag") }}'
 """
@@ -29,7 +32,8 @@ _POLICY_TAG_YML_NO_POLICY_TAGS = """version: 2
 models:
 - name: policy_tag_table
   columns:
-  - name: field
+  - name: first_struct
+  - name: first_struct.field
 """
 
 # Manually generated https://console.cloud.google.com/bigquery/policy-tags?project=dbt-test-env


### PR DESCRIPTION
resolves #687

### Description

This resolves the issue where policy tags attempting to be applied to structs (records) in BigQuery. These can only be applied to leaf nodes as described in the docs [here](https://cloud.google.com/bigquery/docs/column-level-security#struct_or_record)

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
