### PR TITLE
Revert PR 607

### DIFF
--- a/tests/functional/adapter/test_persist_docs.py
+++ b/tests/functional/adapter/test_persist_docs.py
@@ -36,10 +36,18 @@ version: 2
 models:
   - name: table_model_nested
     columns:
+      - name: level_1
+        description: level_1 column description
+      - name: level_1.level_2
+        description: level_2 column description
       - name: level_1.level_2.level_3_a
         description: level_3 column description
   - name: view_model_nested
     columns:
+      - name: level_1
+        description: level_1 column description
+      - name: level_1.level_2
+        description: level_2 column description
       - name: level_1.level_2.level_3_a
         description: level_3 column description
 """
@@ -183,12 +191,23 @@ class TestPersistDocsNested(BasePersistDocsBase):
                 bq_schema = client.get_table(table_id).schema
 
                 level_1_field = bq_schema[0]
+                assert level_1_field.description == "level_1 column description"
+
+                level_2_field = level_1_field.fields[0]
+                assert level_2_field.description == "level_2 column description"
+
                 level_2_field = level_1_field.fields[0]
                 level_3_field = level_2_field.fields[0]
                 assert level_3_field.description == "level_3 column description"
 
             # check the descriptions in the catalog
             node = catalog_data["nodes"]["model.test.{}".format(node_id)]
+
+            level_1_column = node["columns"]["level_1"]
+            assert level_1_column["comment"] == "level_1 column description"
+
+            level_2_column = node["columns"]["level_1.level_2"]
+            assert level_2_column["comment"] == "level_2 column description"
 
             level_3_column = node["columns"]["level_1.level_2.level_3_a"]
             assert level_3_column["comment"] == "level_3 column description"


### PR DESCRIPTION
# Dr. Strangebug: How I Learned to Stop Worrying and Love the Code

Prompted by issue #687 and PR #688 

### Description

Stemming from a lack of documentation, I didn't realize the patch 400 error was happening because policy tags were being applied (but only an empty list of them!) to non leaf fields, namely the inner struct (which itself has an inner struct with leaf fields). My PR #607  was misguided as a result.

#### What's really going on

My current working understanding is that a leaf field is something tied to a STRUCT(). These can have inner (cf. nested) STRUCTS, but these are not leaf fields. Only true columns are leaf fields. Thus, if the data type happens to be a record (the internal type of a STRUCT), his policy tag mechanism errors out with the 400 response.

In pr #542 , this bug was introduced indirectly [at this line](https://github.com/dbt-labs/dbt-bigquery/pull/542/files#diff-96ff53dca401b9ca48009a58b6c77181552b72b2ad6867c37ae2f22f75a5bd38L647) -- we no longer forbid 'empty' policy tag PATCH-es. This happened even in cases with no policy tags because of how `impl.py` has at least an empty list applied to columns (this part is still obscure to me because it happens in BQ's code, not ours -- **_why would an empty list attempt a patch on a model?_**).

#### The root cause

Turns out [we didn't run adapter tests](https://github.com/dbt-labs/dbt-bigquery/pull/688/files) on PR #542 . This is a reminder we must add all test tags to community PRs before merging.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR

