### PR TITLE
increase timeout to flaky grants test

### DIFF
--- a/tests/functional/adapter/test_grant_access_to.py
+++ b/tests/functional/adapter/test_grant_access_to.py
@@ -47,7 +47,7 @@ class TestAccessGrantSucceeds:
         # Need to run twice to validate idempotency
         results = run_dbt(["run"])
         assert len(results) == 2
-        time.sleep(10)
+        time.sleep(30)
         results = run_dbt(["run"])
         assert len(results) == 2
 


### PR DESCRIPTION
resolves #

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->

### Description

grants have been sporadically failing and there's no functional error but a timing issue. Bumping up to 30 seconds so we have a decent buffer and avoid random failures.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
