### PR TITLE
[Fix] small change to test pathing for assert clause

### DIFF
--- a/tests/functional/adapter/upload_file_tests/test_upload_file.py
+++ b/tests/functional/adapter/upload_file_tests/test_upload_file.py
@@ -1,5 +1,6 @@
 import pytest
 from dbt.tests.util import get_relation_columns, run_dbt, run_sql_with_adapter
+from dbt.contracts.results import NodeStatus
 import datetime
 import yaml
 
@@ -75,7 +76,7 @@ class TestUploadFile:
             }
         )
         upload_result = run_dbt(["run-operation", "upload_file", "--args", upload_args])
-        assert upload_result.results[0].status
+        assert upload_result.results[0].status == NodeStatus.Success
 
         # Check if the uploaded table contains expected values and schema
         self.perform_uploaded_table_checks(project.test_schema, "TestUploadFileCSV", project)
@@ -94,7 +95,7 @@ class TestUploadFile:
             }
         )
         upload_result = run_dbt(["run-operation", "upload_file", "--args", upload_args])
-        assert upload_result.results[0].status
+        assert upload_result.results[0].status == NodeStatus.Success
 
         # Check if the uploaded table contains expected values and schema
         self.perform_uploaded_table_checks(project.test_schema, "TestUploadFileNDJSON", project)
@@ -112,7 +113,7 @@ class TestUploadFile:
             }
         )
         upload_result = run_dbt(["run-operation", "upload_file", "--args", upload_args])
-        assert upload_result.results[0].status
+        assert upload_result.results[0].status == NodeStatus.Success
 
         # Check if the uploaded table contains expected values and schema
         self.perform_uploaded_table_checks(project.test_schema, "TestUploadFileParquet", project)

--- a/tests/functional/adapter/upload_file_tests/test_upload_file.py
+++ b/tests/functional/adapter/upload_file_tests/test_upload_file.py
@@ -75,7 +75,7 @@ class TestUploadFile:
             }
         )
         upload_result = run_dbt(["run-operation", "upload_file", "--args", upload_args])
-        assert upload_result.success
+        assert upload_result.results[0].status
 
         # Check if the uploaded table contains expected values and schema
         self.perform_uploaded_table_checks(project.test_schema, "TestUploadFileCSV", project)
@@ -94,7 +94,7 @@ class TestUploadFile:
             }
         )
         upload_result = run_dbt(["run-operation", "upload_file", "--args", upload_args])
-        assert upload_result.success
+        assert upload_result.results[0].status
 
         # Check if the uploaded table contains expected values and schema
         self.perform_uploaded_table_checks(project.test_schema, "TestUploadFileNDJSON", project)
@@ -112,7 +112,7 @@ class TestUploadFile:
             }
         )
         upload_result = run_dbt(["run-operation", "upload_file", "--args", upload_args])
-        assert upload_result.success
+        assert upload_result.results[0].status
 
         # Check if the uploaded table contains expected values and schema
         self.perform_uploaded_table_checks(project.test_schema, "TestUploadFileParquet", project)


### PR DESCRIPTION
resolves #

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->

### Description

changing `upload_result.success` to `upload_result.results[0].status` in upload_file functional tests due to the error `AttributeError: 'RunResultsArtifact' object has no attribute 'success'` because `RunResultArtifacts` doesn't have access to `status` param of `RunResultsOption`/`RunResult` without digging deeper into stack.

This should fix recent ci/cd failures.

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
