### PR TITLE
Standardize the adapter for core debug changes.

### DIFF
--- a/.changes/unreleased/Features-20230604-034603.yaml
+++ b/.changes/unreleased/Features-20230604-034603.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Standardize the _connection_keys and debug_query for `dbt debug`.
+time: 2023-06-04T03:46:03.065575-07:00
+custom:
+  Author: versusfacit
+  Issue: PR754

--- a/dbt/adapters/bigquery/connections.py
+++ b/dbt/adapters/bigquery/connections.py
@@ -168,18 +168,28 @@ class BigQueryCredentials(Credentials):
     def _connection_keys(self):
         return (
             "method",
-            "database",
-            "schema",
+            "project",
+            "execution_project",
             "location",
             "priority",
-            "timeout_seconds",
             "maximum_bytes_billed",
-            "execution_project",
+            "impersonate_service_account",
             "job_retry_deadline_seconds",
             "job_retries",
             "job_creation_timeout_seconds",
             "job_execution_timeout_seconds",
+            "keyfile",
+            "keyfile_json",
+            "timeout_seconds",
+            "token",
+            "refresh_token",
+            "client_id",
+            "client_secret",
+            "token_uri",
+            "dataproc_region",
+            "dataproc_cluster_name",
             "gcs_bucket",
+            "dataproc_batch",
         )
 
     @classmethod

--- a/dbt/adapters/bigquery/connections.py
+++ b/dbt/adapters/bigquery/connections.py
@@ -168,8 +168,9 @@ class BigQueryCredentials(Credentials):
     def _connection_keys(self):
         return (
             "method",
-            "project",
+            "database",
             "execution_project",
+            "schema",
             "location",
             "priority",
             "maximum_bytes_billed",

--- a/dbt/adapters/bigquery/impl.py
+++ b/dbt/adapters/bigquery/impl.py
@@ -978,3 +978,7 @@ class BigQueryAdapter(BaseAdapter):
             return f"{c} not enforced" if c else None
 
         return c
+
+    def debug_query(self):
+        """Override for DebugTask method"""
+        self.execute("select 1 as id")


### PR DESCRIPTION
PR to bring adapter in parity with [this core PR](https://github.com/dbt-labs/dbt-core/pull/7741).

Now will use the bigquery adapter query and will show all credential lines in `_connection_keys`.

### Feedback Requested

In the connection keys, flag any that are sensitive and should not be shown to users in plaintext

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
