### PR TITLE
Pass python model timeout to polling instead of retry

### DIFF
--- a/.changes/unreleased/Fixes-20230609-132727.yaml
+++ b/.changes/unreleased/Fixes-20230609-132727.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Pass python model timeout to polling operation so model execution times out
+  as expected.
+time: 2023-06-09T13:27:27.279842-07:00
+custom:
+  Author: colin-rogers-dbt
+  Issue: "577"

--- a/dbt/adapters/bigquery/python_submissions.py
+++ b/dbt/adapters/bigquery/python_submissions.py
@@ -1,6 +1,8 @@
 from typing import Dict, Union
 
 from dbt.adapters.base import PythonJobHelper
+from google.api_core.future.polling import POLLING_PREDICATE
+
 from dbt.adapters.bigquery import BigQueryConnectionManager, BigQueryCredentials
 from dbt.adapters.bigquery.connections import DataprocBatchConfig
 from google.api_core import retry
@@ -43,7 +45,7 @@ class BaseDataProcHelper(PythonJobHelper):
         self.timeout = self.parsed_model["config"].get(
             "timeout", self.credential.job_execution_timeout_seconds or 60 * 60 * 24
         )
-        self.retry = retry.Retry(maximum=10.0, deadline=self.timeout)
+        self.retry = retry.Retry(predicate=POLLING_PREDICATE, maximum=10.0, timeout=self.timeout)
         self.client_options = ClientOptions(
             api_endpoint="{}-dataproc.googleapis.com:443".format(self.credential.dataproc_region)
         )
@@ -98,7 +100,7 @@ class ClusterDataprocHelper(BaseDataProcHelper):
                 "job": job,
             }
         )
-        response = operation.result(retry=self.retry)
+        response = operation.result(polling=self.retry)
         # check if job failed
         if response.status.state == 6:
             raise ValueError(response.status.details)
@@ -123,7 +125,7 @@ class ServerlessDataProcHelper(BaseDataProcHelper):
         operation = self.job_client.create_batch(request=request)  # type: ignore
         # this takes quite a while, waiting on GCP response to resolve
         # (not a google-api-core issue, more likely a dataproc serverless issue)
-        response = operation.result(retry=self.retry)
+        response = operation.result(polling=self.retry)
         return response
         # there might be useful results here that we can parse and return
         # Dataproc job output is saved to the Cloud Storage bucket

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ passenv =
     DATAPROC_*
     GCS_BUCKET
 commands =
-  bigquery: {envpython} -m pytest {posargs} -vv tests/functional --profile service_account
+  bigquery: {envpython} -m pytest {posargs} -vv tests/functional -k "not TestPython" --profile service_account
 deps =
   -rdev-requirements.txt
   -e.


### PR DESCRIPTION
resolves #577 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->

### Description
GCP async interface offers two configurations that both accept the same type: `retry` and `polling`. The difference is that `retry` configures each individual polling request while `polling` configures the long running operation (i.e. how long to poll for and how frequently to poll). We have been setting `retry` and not `polling` resulting in unexpected behavior in job configuration. 

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-bigquery/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
