### PR TITLE
[Backport 1.1.latest] Dropping support for py37 (#742)

### DIFF
--- a/.changes/unreleased/Breaking Changes-20230530-174051.yaml
+++ b/.changes/unreleased/Breaking Changes-20230530-174051.yaml
@@ -1,0 +1,6 @@
+kind: Breaking Changes
+body: Drop support for python 3.7
+time: 2023-05-30T17:40:51.510639-04:00
+custom:
+  Author: mikealfare
+  Issue: dbt-labs/dbt-core/7082

--- a/.github/scripts/integration-test-matrix.js
+++ b/.github/scripts/integration-test-matrix.js
@@ -1,6 +1,6 @@
 module.exports = ({ context }) => {
   const defaultPythonVersion = "3.8";
-  const supportedPythonVersions = ["3.7", "3.8", "3.9"];
+  const supportedPythonVersions = ["3.8", "3.9"];
   const supportedAdapters = ["bigquery"];
 
   // if PR, generate matrix based on files changed and PR labels

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,7 +71,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8] # TODO: support unit testing for python 3.9 (https://github.com/dbt-labs/dbt/issues/3689)
+        python-version: [3.8, 3.9]
 
     env:
       TOXENV: "unit"
@@ -168,7 +168,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ $EDITOR test.env
 There are a few methods for running tests locally.
 
 #### `tox`
-`tox` takes care of managing Python virtualenvs and installing dependencies in order to run tests. You can also run tests in parallel, for example you can run unit tests for Python 3.7, Python 3.8, Python 3.9, and `flake8` checks in parallel with `tox -p`. Also, you can run unit tests for specific python versions with `tox -e py37`. The configuration of these tests are located in `tox.ini`.
+`tox` takes care of managing Python virtualenvs and installing dependencies in order to run tests. You can also run tests in parallel, for example you can run unit tests for Python 3.8, Python 3.9, and `flake8` checks in parallel with `tox -p`. Also, you can run unit tests for specific python versions with `tox -e py38`. The configuration of these tests are located in `tox.ini`.
 
 #### `pytest`
 Finally, you can also run a specific test or group of tests using `pytest` directly. With a Python virtualenv active and dev dependencies installed you can do things like:

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,9 @@ import sys
 import re
 
 # require python 3.7 or newer
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 8):
     print("Error: dbt does not support this version of Python.")
-    print("Please upgrade to Python 3.7 or higher.")
+    print("Please upgrade to Python 3.8 or higher.")
     sys.exit(1)
 
 
@@ -80,7 +80,6 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: MacOS :: MacOS X",
         "Operating System :: POSIX :: Linux",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 skipsdist = True
-envlist = py37,py38,py39
+envlist = py38,py39
 
-[testenv:{unit,py37,py38,py39,py}]
+[testenv:{unit,py38,py39,py}]
 description = unit testing
 skip_install = true
 passenv =
@@ -13,7 +13,7 @@ deps =
   -rdev-requirements.txt
   -e.
 
-[testenv:{integration,py37,py38,py39,py}-{bigquery}]
+[testenv:{integration,py38,py39,py}-{bigquery}]
 description = adapter plugin integration testing
 skip_install = true
 passenv =


### PR DESCRIPTION
Backport bc8b4a4a3eff0b4a0f0e1a760c35f6e26e4bde21 from #795.