### PR TITLE
Add support for validate_sql method to BigQuery

### DIFF
--- a/.changes/unreleased/Features-20230712-014350.yaml
+++ b/.changes/unreleased/Features-20230712-014350.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add validate_sql to BigQuery adapter and dry_run to BigQueryConnectionManager
+time: 2023-07-12T01:43:50.36167-04:00
+custom:
+  Author: tlento
+  Issue: "805"

--- a/dbt/adapters/bigquery/connections.py
+++ b/dbt/adapters/bigquery/connections.py
@@ -428,7 +428,13 @@ class BigQueryConnectionManager(BaseConnectionManager):
         column_names = [field.name for field in resp.schema]
         return agate_helper.table_from_data_flat(resp, column_names)
 
-    def raw_execute(self, sql, use_legacy_sql=False, limit: Optional[int] = None):
+    def raw_execute(
+        self,
+        sql,
+        use_legacy_sql=False,
+        limit: Optional[int] = None,
+        dry_run: bool = False,
+    ):
         conn = self.get_thread_connection()
         client = conn.handle
 
@@ -446,7 +452,11 @@ class BigQueryConnectionManager(BaseConnectionManager):
         if active_user:
             labels["dbt_invocation_id"] = active_user.invocation_id
 
-        job_params = {"use_legacy_sql": use_legacy_sql, "labels": labels}
+        job_params = {
+            "use_legacy_sql": use_legacy_sql,
+            "labels": labels,
+            "dry_run": dry_run,
+        }
 
         priority = conn.credentials.priority
         if priority == Priority.Batch:
@@ -553,6 +563,37 @@ class BigQueryConnectionManager(BaseConnectionManager):
         )
 
         return response, table
+
+    def dry_run(self, sql: str) -> BigQueryAdapterResponse:
+        """Run the given sql statement with the `dry_run` job parameter set.
+
+        This will allow BigQuery to validate the SQL and immediately return job cost
+        estimates, which we capture in the BigQueryAdapterResponse. Invalid SQL
+        will result in an exception.
+        """
+        sql = self._add_query_comment(sql)
+        query_job, _ = self.raw_execute(sql, dry_run=True)
+
+        # TODO: Factor this repetitive block out into a factory method on
+        # BigQueryAdapterResponse
+        message = f"Ran dry run query for statement of type {query_job.statement_type}"
+        bytes_billed = query_job.total_bytes_billed
+        processed_bytes = self.format_bytes(query_job.total_bytes_processed)
+        location = query_job.location
+        project_id = query_job.project
+        job_id = query_job.job_id
+        slot_ms = query_job.slot_millis
+
+        return BigQueryAdapterResponse(
+            _message=message,
+            code="DRY RUN",
+            bytes_billed=bytes_billed,
+            bytes_processed=processed_bytes,
+            location=location,
+            project_id=project_id,
+            job_id=job_id,
+            slot_ms=slot_ms,
+        )
 
     @staticmethod
     def _bq_job_link(location, project_id, job_id) -> str:

--- a/dbt/adapters/bigquery/impl.py
+++ b/dbt/adapters/bigquery/impl.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 import threading
 from typing import Dict, List, Optional, Any, Set, Union, Type
 
+from dbt.contracts.connection import AdapterResponse
 from dbt.contracts.graph.nodes import ColumnLevelConstraint, ModelLevelConstraint, ConstraintType  # type: ignore
 from dbt.dataclass_schema import dbtClassMixin, ValidationError
 
@@ -1024,3 +1025,12 @@ class BigQueryAdapter(BaseAdapter):
     def debug_query(self):
         """Override for DebugTask method"""
         self.execute("select 1 as id")
+
+    def validate_sql(self, sql: str) -> AdapterResponse:
+        """Submit the given SQL to the engine for validation, but not execution.
+
+        This submits the query with the `dry_run` flag set True.
+
+        :param str sql: The sql to validate
+        """
+        return self.connections.dry_run(sql)


### PR DESCRIPTION
resolves #805

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem
In CLI contexts MetricFlow will issue dry run queries as part
of its warehouse validation operations, and so we are adding a
validate_sql method to all adapters.

The implementation we use for SQLAdapter classes does not
work with BigQuery, as BigQuery does not support the EXPLAIN
keyword.

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

This PR adds support for the validate_sql method to BigQuery. It
does so by creating a BigQuery-specific `dry_run` method on the
BigQueryConnectionManager. This simply passes through the input SQL
with the `dry_run` QueryJobParameter flag set True. This will result
in BigQuery computing and returning a cost estimate for the query,
or raising an exception in the event the query is not valid.

Note: constructing the response object involves some repetitive value
extraction from the QueryResult returned by BigQuery. While I would
ordinariy prefer to tidy this up first we are pressed for time, and so
we postpone that cleanup in order to keep this change as isolated
as possible.


<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
