### PR TITLE
Revert "Add `batch_id` param to profile  to pass along with `dataproc_v1.CreateBatchRequest` (#727)"

### DIFF
--- a/.changes/unreleased/Features-20230517-092205.yaml
+++ b/.changes/unreleased/Features-20230517-092205.yaml
@@ -1,6 +1,0 @@
-kind: Features
-body: Add batch_id param to profile
-time: 2023-05-17T09:22:05.264368+01:00
-custom:
-  Author: nickozilla
-  Issue: "671"

--- a/dbt/adapters/bigquery/connections.py
+++ b/dbt/adapters/bigquery/connections.py
@@ -133,7 +133,6 @@ class BigQueryCredentials(Credentials):
     dataproc_region: Optional[str] = None
     dataproc_cluster_name: Optional[str] = None
     gcs_bucket: Optional[str] = None
-    batch_id: Optional[str] = None
 
     dataproc_batch: Optional[DataprocBatchConfig] = field(
         metadata={

--- a/dbt/adapters/bigquery/python_submissions.py
+++ b/dbt/adapters/bigquery/python_submissions.py
@@ -122,7 +122,6 @@ class ServerlessDataProcHelper(BaseDataProcHelper):
         request = dataproc_v1.CreateBatchRequest(
             parent=parent,
             batch=batch,
-            batch_id=self.credential.batch_id,
         )
         # make the request
         operation = self.job_client.create_batch(request=request)  # type: ignore

--- a/test.env.example
+++ b/test.env.example
@@ -15,4 +15,3 @@ DBT_TEST_USER_3="serviceAccount:dbt-integration-test-user@dbt-test-env.iam.gserv
 DATAPROC_REGION=us-
 DATAPROC_CLUSTER_NAME=
 GCS_BUCKET=
-BATCH_ID=

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,6 @@ def oauth_target():
         "dataproc_region": os.getenv("DATAPROC_REGION"),
         "dataproc_cluster_name": os.getenv("DATAPROC_CLUSTER_NAME"),
         "gcs_bucket": os.getenv("GCS_BUCKET"),
-        "batch_id": os.getenv("BATCH_ID"),
     }
 
 
@@ -54,5 +53,4 @@ def service_account_target():
             "DATAPROC_CLUSTER_NAME"
         ),  # only needed for cluster submission method
         "gcs_bucket": os.getenv("GCS_BUCKET"),
-        "batch_id": os.getenv("BATCH_ID"),
     }


### PR DESCRIPTION
This reverts commit a42e13d8023123102c4d1aeefdfa6cd6246c4768.

resolves #822

We discovered that #727's implementation doesn't work when multiple Python models are used. So we are reverting PR to remove it as a feature shipped as part of `1.6.0`. Instead, we intend to ship an alternate implementation in the next minor version in `1.7.0`
