### PR TITLE
add datadog env vars

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -132,6 +132,11 @@ jobs:
       TOXENV: integration-${{ matrix.adapter }}
       PYTEST_ADDOPTS: "-v --color=yes -n4 --csv integration_results.csv"
       DBT_INVOCATION_ENV: github-actions
+      DD_CIVISIBILITY_AGENTLESS_ENABLED: true
+      DD_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+      DD_SITE: datadoghq.com
+      DD_ENV: ci
+      DD_SERVICE: ${{ github.event.repository.name }}
 
     steps:
       - name: Check out the repository
@@ -179,7 +184,7 @@ jobs:
           DATAPROC_REGION: us-central1
           DATAPROC_CLUSTER_NAME: dbt-test-1
           GCS_BUCKET: dbt-ci
-        run: tox
+        run: tox -- --ddtrace
 
       - uses: actions/upload-artifact@v3
         if: always()

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,6 +8,7 @@ git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-tests-adapter&subdirectory=
 black~=23.3
 bumpversion~=0.6.0
 click~=8.1
+ddtrace~=1.16
 flake8~=6.0
 flaky~=3.7
 freezegun~=1.2

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,8 @@ passenv =
     PYTEST_ADDOPTS
     DATAPROC_*
     GCS_BUCKET
+    DD_SERVICE
+    DD_ENV
 commands =
   bigquery: {envpython} -m pytest {posargs} -vv tests/functional -k "not TestPython" --profile service_account
 deps =
@@ -37,6 +39,8 @@ passenv =
     PYTEST_ADDOPTS
     DATAPROC_*
     GCS_BUCKET
+    DD_SERVICE
+    DD_ENV
 commands =
   {envpython} -m pytest {posargs} -vv tests/functional -k "TestPython" --profile service_account
 deps =


### PR DESCRIPTION
resolves #8081 
~~[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#~~ n/a

### Problem

Datadog not ingesting test data for flaky test visibility

### Solution

Adds env vars to turn on test visibility in datadog.  [Datadog docs](https://docs.datadoghq.com/continuous_integration/tests/python/?tab=cloudciprovideragentless#compatibility)

Updates the tox command to include the `--ddtrace` flag only when running in CI.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me  
- [ ] I have run this code in development and it appears to resolve the stated issue  
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX