### PR TITLE
Update stale workflow to use centralized version

### DIFF
--- a/.changes/unreleased/Under the Hood-20230724-164946.yaml
+++ b/.changes/unreleased/Under the Hood-20230724-164946.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Update stale workflow to use centralized version
+time: 2023-07-24T16:49:46.771984-04:00
+custom:
+  Author: mikealfare
+  Issue: "844"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,17 +1,12 @@
-name: 'Close stale issues and PRs'
+name: "Close stale issues and PRs"
 on:
   schedule:
     - cron: "30 1 * * *"
+
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
-    runs-on: ubuntu-latest
-    steps:
-      # pinned at v4 (https://github.com/actions/stale/releases/tag/v4.0.0)
-      - uses: actions/stale@cdf15f641adb27a71842045a94023bef6945e3aa
-        with:
-          stale-issue-message: "This issue has been marked as Stale because it has been open for 180 days with no activity. If you would like the issue to remain open, please remove the stale label or comment on the issue, or it will be closed in 7 days."
-          stale-pr-message: "This PR has been marked as Stale because it has been open for 180 days with no activity. If you would like the PR to remain open, please remove the stale label or comment on the PR, or it will be closed in 7 days."
-          # mark issues/PRs stale when they haven't seen activity in 180 days
-          days-before-stale: 180
-          # ignore checking issues with the following labels
-          exempt-issue-labels: "epic, discussion"
+    uses: dbt-labs/actions/.github/workflows/stale-bot-matrix.yml@main


### PR DESCRIPTION
### Problem

The stale workflow uses an old version

### Solution

Update the stale workflow to use the centralized version.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX