### PR TITLE
Use execute instead of raw execute to add the query comment as query header

### DIFF
--- a/.changes/unreleased/Under the Hood-20230727-223848.yaml
+++ b/.changes/unreleased/Under the Hood-20230727-223848.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Use execute instead of raw execute to add the query comment as query header
+time: 2023-07-27T22:38:48.258012+02:00
+custom:
+  Author: Kayrnt
+  Issue: "808"

--- a/dbt/adapters/bigquery/impl.py
+++ b/dbt/adapters/bigquery/impl.py
@@ -399,7 +399,7 @@ class BigQueryAdapter(BaseAdapter):
         :param str sql: The sql to execute.
         :return: List[BigQueryColumn]
         """
-        _, iterator = self.connections.raw_execute(sql)
+        _, iterator = self.connections.execute(sql)
         columns = [self.Column.create_from_field(field) for field in iterator.schema]
         flattened_columns = []
         for column in columns:
@@ -411,7 +411,7 @@ class BigQueryAdapter(BaseAdapter):
         try:
             conn = self.connections.get_thread_connection()
             client = conn.handle
-            query_job, iterator = self.connections.raw_execute(select_sql)
+            query_job, iterator = self.connections.execute(select_sql)
             query_table = client.get_table(query_job.destination)
             return self._get_dbt_columns_from_bq_table(query_table)
 


### PR DESCRIPTION
resolves dbt-labs/dbt-adapters#1090

### Problem

Intermediate queries involving:
- `get_column_schema_from_query`
- `get_columns_in_select_sql`

were using `raw_execute` which doesn't add `sql = self._add_query_comment(sql)` resulting in queries that miss the header.

### Solution

Replace the calls from `raw_execute` to `execute` on both functions

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
