### PR TITLE
Move Alerts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,4 +225,4 @@ jobs:
       status: "failure"
 
     secrets:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DEV_CORE_ALERTS }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DEV_ADAPTER_ALERTS }}


### PR DESCRIPTION
Moves alerts to the new adapter channel. The secret is already there so we don't need to wait to merge.