### PR TITLE
Fix contact validation failure on query data types change

### DIFF
--- a/.changes/unreleased/Fixes-20230804-005817.yaml
+++ b/.changes/unreleased/Fixes-20230804-005817.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix contact validation failure on query data types change
+time: 2023-08-04T00:58:17.97704+03:00
+custom:
+  Author: dementiev27
+  Issue: "861"

--- a/dbt/include/bigquery/macros/adapters/columns.sql
+++ b/dbt/include/bigquery/macros/adapters/columns.sql
@@ -1,0 +1,10 @@
+{% macro bigquery__get_empty_subquery_sql(select_sql, select_sql_header=none) %}
+    {%- if select_sql_header is not none -%}
+    {{ select_sql_header }}
+    {%- endif -%}
+    select * from (
+        {{ select_sql }}
+    ) as __dbt_sbq
+    where false and current_timestamp() = current_timestamp()
+    limit 0
+{% endmacro %}


### PR DESCRIPTION
resolves #861

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->
Model data types are being detected incorrectly due to empty query caching in BigQuery, resulting in contact validation errors.

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->
Added `current_timestamp() = current_timestamp()` to the "where" clause in `get_empty_subquery_sql` to prevent query caching.
Original file: [link](https://github.com/dbt-labs/dbt-core/blob/83d163add58838b14638d21f59ab5a4510d24031/core/dbt/include/global_project/macros/adapters/columns.sql#L28-L37).

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
