### PR TITLE
Remove walrus operator to make 1.5 py37 compatible

### DIFF
--- a/.changes/unreleased/Fixes-20230808-113928.yaml
+++ b/.changes/unreleased/Fixes-20230808-113928.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Revert usage of the walrus operator to extend py37 support
+time: 2023-08-08T11:39:28.603598-04:00
+custom:
+  Author: mikealfare
+  Issue: "868"

--- a/dbt/adapters/bigquery/column.py
+++ b/dbt/adapters/bigquery/column.py
@@ -227,7 +227,8 @@ def _update_nested_column_data_types(
             else None
         )
 
-        if existing_nested_column_data_type := nested_column_data_types.get(root_column_name):
+        existing_nested_column_data_type = nested_column_data_types.get(root_column_name)
+        if existing_nested_column_data_type:
             assert isinstance(existing_nested_column_data_type, dict)  # keeping mypy happy
             # entry could already exist if this is a parent column -- preserve the parent data type under "_PARENT_DATA_TYPE_KEY"
             existing_nested_column_data_type.update(


### PR DESCRIPTION
### Problem

We backported a change to v1.5 that used the walrus operator, which was introduces in py38. While our goal is to drop support for py37 going forward, this is a small change that would keep v1.5 py37 compatible for a bit longer.

### Solution

Replace the walrus operator with an equivalent two lines.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
