### PR TITLE
ADAP-773: [backport] Resolve dependency conflicts between google-cloud-<x> packages

### DIFF
--- a/.changes/unreleased/Dependencies-20230809-161527.yaml
+++ b/.changes/unreleased/Dependencies-20230809-161527.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Loosen requirements to avoid version conflicts between google-cloud-<x> packages
+time: 2023-08-09T16:15:27.691942-04:00
+custom:
+  Author: mikealfare
+  PR: "871"

--- a/setup.py
+++ b/setup.py
@@ -67,13 +67,9 @@ setup(
     include_package_data=True,
     install_requires=[
         "dbt-core~={}".format(dbt_core_version),
-        "protobuf>=3.13.0,<4",
-        "google-cloud-core>=1.3.3,<3",
-        "google-cloud-bigquery>=1.25.0,<3",
-        "google-api-core>=1.16.0,<3",
-        "googleapis-common-protos>=1.6.0,<2",
-        "google-cloud-storage>=2.4.0",
-        "google-cloud-dataproc>=4.0.3",
+        "google-cloud-bigquery~=3.0",
+        "google-cloud-storage~=2.4",
+        "google-cloud-dataproc~=5.0",
     ],
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
### Problem

We were too aggressive when pinning versions on google-cloud packages. We wound up in a state with no viable resolution.

### Solution

We had run into this with 1.4+ already, so that fix was applied here. It results in loosening the requirements and removing dependent packages that would otherwise be installed via another google-cloud package.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
