### PR TITLE
[Backport 1.3.latest] add env vars for datadog test visibility

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -22,8 +22,11 @@ passenv =
     PYTEST_ADDOPTS
     DATAPROC_*
     GCS_BUCKET
-    DD_SERVICE
+    DD_CIVISIBILITY_AGENTLESS_ENABLED
+    DD_API_KEY
+    DD_SITE
     DD_ENV
+    DD_SERVICE
 commands =
   bigquery: {envpython} -m pytest {posargs} -m profile_bigquery tests/integration
   bigquery: {envpython} -m pytest {posargs} -vv tests/functional --profile service_account


### PR DESCRIPTION
Backport eb1b97edaf82168ca9837447e4b5d75d874099b7 from #875.