### PR TITLE
case insensitive check on partition matching

### DIFF
--- a/.changes/unreleased/Fixes-20230818-214616.yaml
+++ b/.changes/unreleased/Fixes-20230818-214616.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: case insensitive check on partition matching
+time: 2023-08-18T21:46:16.828488+02:00
+custom:
+  Author: Kayrnt
+  Issue: "886"

--- a/dbt/adapters/bigquery/__init__.py
+++ b/dbt/adapters/bigquery/__init__.py
@@ -2,7 +2,7 @@ from dbt.adapters.bigquery.connections import BigQueryConnectionManager  # noqa
 from dbt.adapters.bigquery.connections import BigQueryCredentials
 from dbt.adapters.bigquery.relation import BigQueryRelation  # noqa
 from dbt.adapters.bigquery.column import BigQueryColumn  # noqa
-from dbt.adapters.bigquery.impl import BigQueryAdapter, GrantTarget  # noqa
+from dbt.adapters.bigquery.impl import BigQueryAdapter, GrantTarget, PartitionConfig  # noqa
 
 from dbt.adapters.base import AdapterPlugin
 from dbt.include import bigquery

--- a/dbt/adapters/bigquery/impl.py
+++ b/dbt/adapters/bigquery/impl.py
@@ -624,7 +624,7 @@ class BigQueryAdapter(BaseAdapter):
             table_granularity = table.partitioning_type
             conf_table_field = conf_partition.field
             return (
-                table_field.lower() == conf_table_field.lower()
+                table_field == conf_table_field.lower()
                 or (conf_partition.time_ingestion_partitioning and table_field is not None)
             ) and table_granularity.lower() == conf_partition.granularity.lower()
         elif conf_partition and table.range_partitioning is not None:

--- a/dbt/adapters/bigquery/impl.py
+++ b/dbt/adapters/bigquery/impl.py
@@ -620,12 +620,13 @@ class BigQueryAdapter(BaseAdapter):
             table_field = (
                 table.time_partitioning.field.lower() if table.time_partitioning.field else None
             )
+
             table_granularity = table.partitioning_type
             conf_table_field = conf_partition.field
             return (
-                table_field == conf_table_field
+                table_field.lower() == conf_table_field.lower()
                 or (conf_partition.time_ingestion_partitioning and table_field is not None)
-            ) and table_granularity == conf_partition.granularity
+            ) and table_granularity.lower() == conf_partition.granularity.lower()
         elif conf_partition and table.range_partitioning is not None:
             dest_part = table.range_partitioning
             conf_part = conf_partition.range or {}


### PR DESCRIPTION
resolves #886

### Problem

The API returns sometimes upper cased fields such `timePartitioning.type` and in case the user config has also a different casing, we should do a case insensitive check on partition matching.

### Solution

It introduce a proper case insensitive check on partition field matching

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
