### PR TITLE
ADAP-842: Reformat macro file structure to be more modular and organizaed

### DIFF
--- a/.changes/unreleased/Under the Hood-20230829-122918.yaml
+++ b/.changes/unreleased/Under the Hood-20230829-122918.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Re-organize adapters.sql into more granular files inside of macros/relations
+time: 2023-08-29T12:29:18.356174-04:00
+custom:
+  Author: mikealfare
+  Issue: "904"

--- a/dbt/include/bigquery/macros/relations/cluster.sql
+++ b/dbt/include/bigquery/macros/relations/cluster.sql
@@ -1,0 +1,13 @@
+{% macro cluster_by(raw_cluster_by) %}
+  {%- if raw_cluster_by is not none -%}
+  cluster by {% if raw_cluster_by is string -%}
+    {% set raw_cluster_by = [raw_cluster_by] %}
+  {%- endif -%}
+  {%- for cluster in raw_cluster_by -%}
+    {{ cluster }}
+    {%- if not loop.last -%}, {% endif -%}
+  {%- endfor -%}
+
+  {% endif %}
+
+{%- endmacro -%}

--- a/dbt/include/bigquery/macros/relations/drop.sql
+++ b/dbt/include/bigquery/macros/relations/drop.sql
@@ -1,0 +1,5 @@
+{% macro bigquery__drop_relation(relation) -%}
+  {% call statement('drop_relation') -%}
+    drop {{ relation.type }} if exists {{ relation }}
+  {%- endcall %}
+{% endmacro %}

--- a/dbt/include/bigquery/macros/relations/options.sql
+++ b/dbt/include/bigquery/macros/relations/options.sql
@@ -1,0 +1,8 @@
+{% macro bigquery_options(opts) %}
+  {% set options -%}
+    OPTIONS({% for opt_key, opt_val in opts.items() %}
+      {{ opt_key }}={{ opt_val }}{{ "," if not loop.last }}
+    {% endfor %})
+  {%- endset %}
+  {%- do return(options) -%}
+{%- endmacro -%}

--- a/dbt/include/bigquery/macros/relations/partition.sql
+++ b/dbt/include/bigquery/macros/relations/partition.sql
@@ -1,0 +1,15 @@
+{% macro partition_by(partition_config) -%}
+    {%- if partition_config is none -%}
+      {% do return('') %}
+    {%- elif partition_config.time_ingestion_partitioning -%}
+        partition by {{ partition_config.render_wrapped() }}
+    {%- elif partition_config.data_type | lower in ('date','timestamp','datetime') -%}
+        partition by {{ partition_config.render() }}
+    {%- elif partition_config.data_type | lower in ('int64') -%}
+        {%- set range = partition_config.range -%}
+        partition by range_bucket(
+            {{ partition_config.field }},
+            generate_array({{ range.start}}, {{ range.end }}, {{ range.interval }})
+        )
+    {%- endif -%}
+{%- endmacro -%}

--- a/dbt/include/bigquery/macros/relations/rename.sql
+++ b/dbt/include/bigquery/macros/relations/rename.sql
@@ -1,0 +1,3 @@
+{% macro bigquery__rename_relation(from_relation, to_relation) -%}
+  {% do adapter.rename_relation(from_relation, to_relation) %}
+{% endmacro %}

--- a/dbt/include/bigquery/macros/relations/table/options.sql
+++ b/dbt/include/bigquery/macros/relations/table/options.sql
@@ -1,0 +1,4 @@
+{% macro bigquery_table_options(config, node, temporary) %}
+  {% set opts = adapter.get_table_options(config, node, temporary) %}
+  {%- do return(bigquery_options(opts)) -%}
+{%- endmacro -%}

--- a/dbt/include/bigquery/macros/relations/view/options.sql
+++ b/dbt/include/bigquery/macros/relations/view/options.sql
@@ -1,0 +1,4 @@
+{% macro bigquery_view_options(config, node) %}
+  {% set opts = adapter.get_view_options(config, node) %}
+  {%- do return(bigquery_options(opts)) -%}
+{%- endmacro -%}


### PR DESCRIPTION
### Problem

Materialized views work will require macros that are relation-agnostic dispatching to relation-specific macros. This will make `adapters.sql` more difficult to understand, and the resulting PR more difficult to process.

### Solution

Break the MV work into refactoring and feature work. This PR represents the refactoring half, where macros are moved but not altered. The code and signature remain the same. This is effectively the same code, but moved to different files (which does not affect how the macros are read).

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
