### PR TITLE
quote column names in data types

### DIFF
--- a/.changes/unreleased/Fixes-20230911-005506.yaml
+++ b/.changes/unreleased/Fixes-20230911-005506.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Quote column names in struct data types to fix time ingestion partitioning table
+  creation
+time: 2023-09-11T00:55:06.904238+02:00
+custom:
+  Author: Kayrnt
+  Issue: "913"

--- a/dbt/adapters/bigquery/column.py
+++ b/dbt/adapters/bigquery/column.py
@@ -82,7 +82,7 @@ class BigQueryColumn(Column):
     def data_type(self) -> str:
         if self.dtype.upper() == "RECORD":
             subcols = [
-                "`{}` {}".format(col.name, col.data_type) for col in self.fields  # type: ignore[attr-defined]
+                "{} {}".format(col.quoted, col.data_type) for col in self.fields  # type: ignore[attr-defined]
             ]
             field_type = "STRUCT<{}>".format(", ".join(subcols))
 

--- a/dbt/adapters/bigquery/column.py
+++ b/dbt/adapters/bigquery/column.py
@@ -82,7 +82,7 @@ class BigQueryColumn(Column):
     def data_type(self) -> str:
         if self.dtype.upper() == "RECORD":
             subcols = [
-                "{} {}".format(col.name, col.data_type) for col in self.fields  # type: ignore[attr-defined]
+                "`{}` {}".format(col.name, col.data_type) for col in self.fields  # type: ignore[attr-defined]
             ]
             field_type = "STRUCT<{}>".format(", ".join(subcols))
 

--- a/tests/functional/adapter/incremental/test_incremental_on_schema_change.py
+++ b/tests/functional/adapter/incremental/test_incremental_on_schema_change.py
@@ -82,19 +82,23 @@ with data as (
         select 1 as id,
         cast('2020-01-01 01:00:00' as datetime) as date_hour,
         1 as field_1,
-        2 as field_2 union all
+        2 as field_2,
+        STRUCT(1 as `group`) union all
         select 2 as id,
         cast('2020-01-01 01:00:00' as datetime) as date_hour,
         1 as field_1,
-        2 as field_2 union all
+        2 as field_2,
+        STRUCT(1 as `group`) union all
         select 3 as id,
         cast('2020-01-01 01:00:00' as datetime) as date_hour,
         1 as field_1,
-        2 as field_2 union all
+        2 as field_2,
+        STRUCT(2 as `group`) union all
         select 4 as id,
         cast('2020-01-01 01:00:00' as datetime) as date_hour,
         1 as field_1,
-        2 as field_2
+        2 as field_2,
+        STRUCT(2 as `group`)
 
     {% else %}
 

--- a/tests/functional/adapter/incremental/test_incremental_on_schema_change.py
+++ b/tests/functional/adapter/incremental/test_incremental_on_schema_change.py
@@ -83,22 +83,22 @@ with data as (
         cast('2020-01-01 01:00:00' as datetime) as date_hour,
         1 as field_1,
         2 as field_2,
-        STRUCT(1 as `group`) union all
+        STRUCT(1 as `group`, 2 as `WHERE`, 3 as group_2, 4 as WHERE_TO) as field_struct union all
         select 2 as id,
         cast('2020-01-01 01:00:00' as datetime) as date_hour,
         1 as field_1,
         2 as field_2,
-        STRUCT(1 as `group`) union all
+        STRUCT(1 as `group`, 2 as `WHERE`, 3 as group_2, 4 as WHERE_TO) union all
         select 3 as id,
         cast('2020-01-01 01:00:00' as datetime) as date_hour,
         1 as field_1,
         2 as field_2,
-        STRUCT(2 as `group`) union all
+        STRUCT(2 as `group`, 2 as `WHERE`, 3 as group_2, 4 as WHERE_TO) union all
         select 4 as id,
         cast('2020-01-01 01:00:00' as datetime) as date_hour,
         1 as field_1,
         2 as field_2,
-        STRUCT(2 as `group`)
+        STRUCT(2 as `group`, 2 as `WHERE`, 3 as group_2, 4 as WHERE_TO)
 
     {% else %}
 


### PR DESCRIPTION
to fix time ingestion partitioning table creation

resolves #913

### Problem

When time ingestion table are created, every field is used with their data types to generate the DDL statement.
When using fields in a STRUCT that contains a field that is a reserved word, it would fail if it's not quoted which is the current issue.

### Solution

Adding the quote in the data types of struct elements should fix the problem.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
