### PR TITLE
Add tests for `date_spine` macro, and sub macros

### DIFF
--- a/tests/functional/adapter/utils/fixture_get_intervals_between.py
+++ b/tests/functional/adapter/utils/fixture_get_intervals_between.py
@@ -1,0 +1,16 @@
+models__bq_test_get_intervals_between_sql = """
+SELECT
+  {{ get_intervals_between("'2023-09-01'", "'2023-09-12'", "day") }} as intervals,
+  11 as expected
+
+"""
+
+models___bq_test_get_intervals_between_yml = """
+version: 2
+models:
+  - name: test_get_intervals_between
+    tests:
+      - assert_equal:
+          actual: intervals
+          expected: expected
+"""

--- a/tests/functional/adapter/utils/test_utils.py
+++ b/tests/functional/adapter/utils/test_utils.py
@@ -45,6 +45,10 @@ from tests.functional.adapter.utils.fixture_array_construct import (
     models__array_construct_expected_sql,
     macros__array_to_string_sql,
 )
+from tests.functional.adapter.utils.fixture_get_intervals_between import (
+    models__bq_test_get_intervals_between_sql,
+    models___bq_test_get_intervals_between_yml,
+)
 
 
 class TestAnyValue(BaseAnyValue):
@@ -141,8 +145,15 @@ class TestGenerateSeries(BaseGenerateSeries):
     pass
 
 
-class TestGetIntervalsBeteween(BaseGetIntervalsBetween):
-    pass
+class TestGetIntervalsBetween(BaseGetIntervalsBetween):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "test_get_intervals_between.yml": models___bq_test_get_intervals_between_yml,
+            "test_get_intervals_between.sql": self.interpolate_macro_namespace(
+                models__bq_test_get_intervals_between_sql, "get_intervals_between"
+            ),
+        }
 
 
 class TestGetPowersOfTwo(BaseGetPowersOfTwo):

--- a/tests/functional/adapter/utils/test_utils.py
+++ b/tests/functional/adapter/utils/test_utils.py
@@ -13,9 +13,13 @@ from dbt.tests.adapter.utils.test_concat import BaseConcat
 from dbt.tests.adapter.utils.test_current_timestamp import BaseCurrentTimestampAware
 from dbt.tests.adapter.utils.test_dateadd import BaseDateAdd
 from dbt.tests.adapter.utils.test_datediff import BaseDateDiff
+from dbt.tests.adapter.utils.test_date_spine import BaseDateSpine
 from dbt.tests.adapter.utils.test_date_trunc import BaseDateTrunc
 from dbt.tests.adapter.utils.test_escape_single_quotes import BaseEscapeSingleQuotesBackslash
 from dbt.tests.adapter.utils.test_except import BaseExcept
+from dbt.tests.adapter.utils.test_generate_series import BaseGenerateSeries
+from dbt.tests.adapter.utils.test_get_intervals_between import BaseGetIntervalsBetween
+from dbt.tests.adapter.utils.test_get_powers_of_two import BaseGetPowersOfTwo
 from dbt.tests.adapter.utils.test_hash import BaseHash
 from dbt.tests.adapter.utils.test_intersect import BaseIntersect
 from dbt.tests.adapter.utils.test_last_day import BaseLastDay
@@ -117,6 +121,10 @@ class TestDateDiff(BaseDateDiff):
     pass
 
 
+class TestDateSpine(BaseDateSpine):
+    pass
+
+
 class TestDateTrunc(BaseDateTrunc):
     pass
 
@@ -126,6 +134,18 @@ class TestEscapeSingleQuotes(BaseEscapeSingleQuotesBackslash):
 
 
 class TestExcept(BaseExcept):
+    pass
+
+
+class TestGenerateSeries(BaseGenerateSeries):
+    pass
+
+
+class TestGetIntervalsBeteween(BaseGetIntervalsBetween):
+    pass
+
+
+class TestGetPowersOfTwo(BaseGetPowersOfTwo):
     pass
 
 


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-core/issues/8172

### Problem

In https://github.com/dbt-labs/dbt-core/issues/8172 we moved the `date_spine` macro and sub macros from dbt-utils to dbt-core. As such we should begin testing these macros to ensure they work properly on this adapter.

### Solution

Begin running the tests for the `date_spine` macro and sub macros

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
