### PR TITLE
[fix] Use rendered query comment for job labels

### DIFF
--- a/.changes/unreleased/Fixes-20231005-235950.yaml
+++ b/.changes/unreleased/Fixes-20231005-235950.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix issue where job labels are not rendered when using macro for query comment
+time: 2023-10-05T23:59:50.077842+02:00
+custom:
+  Author: kodaho mikealfare
+  Issue: "863"

--- a/dbt/adapters/bigquery/connections.py
+++ b/dbt/adapters/bigquery/connections.py
@@ -451,9 +451,10 @@ class BigQueryConnectionManager(BaseConnectionManager):
             hasattr(self.profile, "query_comment")
             and self.profile.query_comment
             and self.profile.query_comment.job_label
+            and self.query_header
+            and (query_comment := self.query_header.comment.query_comment)
         ):
-            query_comment = self.profile.query_comment
-            labels = self._labels_from_query_comment(query_comment.comment)
+            labels = self._labels_from_query_comment(query_comment)
         else:
             labels = {}
 

--- a/tests/functional/adapter/query_comment_test/test_job_label.py
+++ b/tests/functional/adapter/query_comment_test/test_job_label.py
@@ -8,7 +8,7 @@ from dbt.tests.util import run_dbt
 _MACRO__BQ_LABELS = """
 {% macro bq_labels() %}{
     "system": "{{ env_var('LABEL_SYSTEM', 'my_system') }}",
-    "env_type": "{{ env_var('LABEL_ENV', 'dev') }}",
+    "env_type": "{{ env_var('LABEL_ENV', 'dev') }}"
 }{% endmacro %}
 """
 _MODEL__MY_TABLE = """

--- a/tests/functional/adapter/query_comment_test/test_job_label.py
+++ b/tests/functional/adapter/query_comment_test/test_job_label.py
@@ -1,0 +1,52 @@
+import pytest
+
+from google.cloud.bigquery.client import Client
+
+from dbt.tests.util import run_dbt
+
+
+_MACRO__BQ_LABELS = """
+{% macro bq_labels() %}{
+    "system": "{{ env_var('LABEL_SYSTEM', 'my_system') }}",
+    "env_type": "{{ env_var('LABEL_ENV', 'dev') }}",
+}{% endmacro %}
+"""
+_MODEL__MY_TABLE = """
+{{ config(materialized= "table") }}
+select 1 as id
+"""
+
+
+class TestQueryCommentJobLabel:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"my_table.sql": _MODEL__MY_TABLE}
+
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {"bq_labels.sql": _MACRO__BQ_LABELS}
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "query-comment": {
+                "comment": "{{ bq_labels() }}",
+                "job-label": True,
+                "append": True,
+            }
+        }
+
+    def test_query_comments_displays_as_job_labels(self, project):
+        """
+        Addresses this regression in dbt-bigquery 1.6:
+        https://github.com/dbt-labs/dbt-bigquery/issues/863
+        """
+        results = run_dbt(["run"])
+        job_id = results.results[0].adapter_response.get("job_id")
+        with project.adapter.connection_named("_test"):
+            client: Client = project.adapter.connections.get_thread_connection().handle
+            job = client.get_job(job_id=job_id)
+
+        # this is what should happen
+        assert job.labels.get("system") == "my_system"
+        assert job.labels.get("env_type") == "dev"


### PR DESCRIPTION
resolves #863

### Problem

A regression appears in the last release of `dbt-bigquery`. A user can previously add labels to a BigQuery job thanks to a macro returning a mapping. In the version 1.6.0, this was no longer possible even if the project is set to activate this feature. 

### Solution

The proposed solution is to use, instead of `self.profile.query_comment` (which is the not-rendered Jinja macro), `self.query_header.comment.query_comment` (the JSON rendered query comments).

I added some safeguards to make sure that `self.query_header.comment.query_comment` is not null but during the runtime, it should never be the case because of the following succession of functions and methods calls during a run command:
1. The query labels are sent with a `run` command, [command decorated with the decorator `requires.manifest`](https://github.com/dbt-labs/dbt-core/blob/f30293359ce709d7b017b09482124b72e8013b0e/core/dbt/cli/main.py#L589).
2. The class method [`ManifestLoader.get_full_manifest`](https://github.com/dbt-labs/dbt-core/blob/f30293359ce709d7b017b09482124b72e8013b0e/core/dbt/cli/requires.py#L271) is called.
3. The method [`ManifestLoader().save_macros_to_adapter`](https://github.com/dbt-labs/dbt-core/blob/f30293359ce709d7b017b09482124b72e8013b0e/core/dbt/parser/manifest.py#L324C20-L324C42) is called.
4. `ManifestLoader().macro_hook` is called, knowing that [`macro_hook = adapter.connections.set_query_header`](https://github.com/dbt-labs/dbt-core/blob/f30293359ce709d7b017b09482124b72e8013b0e/core/dbt/parser/manifest.py#L287).
5. Calling `Connection().set_query_header` makes sure that `self.query_header` is not null.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
