### PR TITLE
[Backport] PRs 955 and 957 to 1.5.latest

### DIFF
--- a/.changes/unreleased/Fixes-20231005-235950.yaml
+++ b/.changes/unreleased/Fixes-20231005-235950.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix issue where job labels are not rendered when using macro for query comment
+time: 2023-10-05T23:59:50.077842+02:00
+custom:
+  Author: kodaho mikealfare
+  Issue: "863"

--- a/tests/functional/adapter/query_comment_test/test_job_label.py
+++ b/tests/functional/adapter/query_comment_test/test_job_label.py
@@ -1,0 +1,53 @@
+import pytest
+
+from google.cloud.bigquery.client import Client
+
+from dbt.tests.util import run_dbt
+
+
+_MACRO__BQ_LABELS = """
+{% macro bq_labels() %}{
+    "system": "{{ env_var('LABEL_SYSTEM', 'my_system') }}",
+    "env_type": "{{ env_var('LABEL_ENV', 'dev') }}"
+}{% endmacro %}
+"""
+_MODEL__MY_TABLE = """
+{{ config(materialized= "table") }}
+select 1 as id
+"""
+
+
+class TestQueryCommentJobLabel:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"my_table.sql": _MODEL__MY_TABLE}
+
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {"bq_labels.sql": _MACRO__BQ_LABELS}
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "query-comment": {
+                "comment": "{{ bq_labels() }}",
+                "job-label": True,
+                "append": True,
+            }
+        }
+
+    def test_query_comments_displays_as_job_labels(self, project):
+        """
+        Addresses this regression in dbt-bigquery 1.6:
+        https://github.com/dbt-labs/dbt-bigquery/issues/863
+        """
+        results = run_dbt(["run"])
+        job_id = results.results[0].adapter_response.get("job_id")
+        with project.adapter.connection_named("_test"):
+            client: Client = project.adapter.connections.get_thread_connection().handle
+            job = client.get_job(job_id=job_id)
+
+        # this is what should happen
+        assert job.labels.get("system") == "my_system"
+        assert job.labels.get("env_type") == "dev"
+        


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-bigquery/issues/863
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

Problem
A regression appears in the last release of dbt-bigquery. A user can previously add labels to a BigQuery job thanks to a macro returning a mapping. In the version 1.6.0, this was no longer possible even if the project is set to activate this feature.

Solution
https://github.com/dbt-labs/dbt-bigquery/pull/955
The proposed solution is to use, instead of self.profile.query_comment (which is the not-rendered Jinja macro), self.query_header.comment.query_comment (the JSON rendered query comments).

https://github.com/dbt-labs/dbt-bigquery/pull/957
to functionalize the small snippet and create a small change by making it to two nested if statements and moving the empty set of variable to top of function.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
