### PR TITLE
test against 1.7.latest release branch and fix semver

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -26,7 +26,7 @@ defaults:
     shell: bash
 
 env:
-  RELEASE_BRANCH: "1.7.latest" # must test against most recent .latest branch to have parity for dependency with core
+  RELEASE_BRANCH: "1.6.latest" # must test against most recent .latest branch to have parity for dependency with core
 
 jobs:
   aggregate-release-data:

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -26,7 +26,7 @@ defaults:
     shell: bash
 
 env:
-  RELEASE_BRANCH: "1.5.latest" # must test against most recent .latest branch to have parity for dependency with core
+  RELEASE_BRANCH: "1.7.latest" # must test against most recent .latest branch to have parity for dependency with core
 
 jobs:
   aggregate-release-data:
@@ -75,7 +75,7 @@ jobs:
       - name: "Generate Nightly Release Version Number"
         id: nightly-release-version
         run: |
-          number="${{ steps.semver.outputs.major }}.${{ steps.semver.outputs.minor }}.${{ steps.bump_patch.outputs.patch }}.dev${{ steps.current-date.outputs.date }}"
+          number="${{ steps.semver.outputs.major }}.${{ steps.semver.outputs.minor }}.${{ steps.bump_patch.outputs.patch }}+dev${{ steps.current-date.outputs.date }}"
           echo "number=$number" >> $GITHUB_OUTPUT
 
       - name: "Audit Nightly Release Version And Parse Into Parts"

--- a/tests/functional/adapter/test_grant_access_to.py
+++ b/tests/functional/adapter/test_grant_access_to.py
@@ -87,15 +87,6 @@ class TestAccessGrantSucceeds:
 
 
 class TestAccessGrantFails:
-    @pytest.fixture(scope="class", autouse=True)
-    def setup(self, project):
-        with project.adapter.connection_named("__test_grants"):
-            relation = project.adapter.Relation.create(
-                database=project.database, schema=f"{project.test_schema}_seeds"
-            )
-            yield relation
-            project.adapter.drop_relation(relation)
-
     @pytest.fixture(scope="class")
     def models(self):
         return {

--- a/tests/functional/adapter/test_grant_access_to.py
+++ b/tests/functional/adapter/test_grant_access_to.py
@@ -95,6 +95,7 @@ class TestAccessGrantFails:
             )
             yield relation
             project.adapter.drop_relation(relation)
+
     @pytest.fixture(scope="class")
     def models(self):
         return {

--- a/tests/functional/adapter/test_grant_access_to.py
+++ b/tests/functional/adapter/test_grant_access_to.py
@@ -87,6 +87,14 @@ class TestAccessGrantSucceeds:
 
 
 class TestAccessGrantFails:
+    @pytest.fixture(scope="class", autouse=True)
+    def setup(self, project):
+        with project.adapter.connection_named("__test_grants"):
+            relation = project.adapter.Relation.create(
+                database=project.database, schema=f"{project.test_schema}_seeds"
+            )
+            yield relation
+            project.adapter.drop_relation(relation)
     @pytest.fixture(scope="class")
     def models(self):
         return {


### PR DESCRIPTION
Currently nightly release tests fail since core does not view the supplied adapter version as valid semver: 
`dbt.exceptions.SemverError: "1.5.6.dev10092023" is not a valid semantic version.` 
This change would have "dev" be a build tag instead of a patch version, so the new version be: 1.5.6+dev10092023
resolves #
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
