### PR TITLE
Patch for `dbt show` for a model with a `struct` column containing a `json` datatype

### DIFF
--- a/.changes/unreleased/Fixes-20231021-154237.yaml
+++ b/.changes/unreleased/Fixes-20231021-154237.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Patch for json inline --show
+time: 2023-10-21T15:42:37.406853-06:00
+custom:
+  Author: matt.winkler@dbtlabs.com
+  Issue: "972"

--- a/.changes/unreleased/Fixes-20231023-082312.yaml
+++ b/.changes/unreleased/Fixes-20231023-082312.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Patch for json inline --show
+time: 2023-10-23T08:23:12.245223-06:00
+custom:
+  Author: matt-winkler
+  Issue: "972"

--- a/dbt/adapters/bigquery/connections.py
+++ b/dbt/adapters/bigquery/connections.py
@@ -15,7 +15,7 @@ from typing import Optional, Any, Dict, Tuple
 
 import google.auth
 import google.auth.exceptions
-import google.cloud.bigquery
+import google.cloud.bigquery as bigquery
 import google.cloud.exceptions
 from google.api_core import retry, client_info
 from google.auth import impersonated_credentials
@@ -61,6 +61,15 @@ RETRYABLE_ERRORS = (
     ConnectionResetError,
     ConnectionError,
 )
+
+
+# Override broken json deserializer for dbt show --inline
+def _json_from_json(value, _):
+    """NOOP string -> string coercion"""
+    return json.loads(value)
+
+
+bigquery._helpers._CELLDATA_FROM_JSON["JSON"] = _json_from_json
 
 
 @lru_cache()

--- a/dbt/adapters/bigquery/connections.py
+++ b/dbt/adapters/bigquery/connections.py
@@ -64,6 +64,7 @@ RETRYABLE_ERRORS = (
 
 
 # Override broken json deserializer for dbt show --inline
+# can remove once this is fixed: https://github.com/googleapis/python-bigquery/issues/1500
 def _json_from_json(value, _):
     """NOOP string -> string coercion"""
     return json.loads(value)

--- a/tests/functional/adapter/dbt_show/test_dbt_show.py
+++ b/tests/functional/adapter/dbt_show/test_dbt_show.py
@@ -33,6 +33,8 @@ class TestBigQueryShowSqlHeader(BaseShowSqlHeader):
     pass
 
 
+# Added to check if dbt show works with JSON struct
+# Addresses: https://github.com/dbt-labs/dbt-bigquery/issues/972
 class TestBigQueryShowSqlWorksWithJSONStruct:
     @pytest.fixture(scope="class")
     def models(self):

--- a/tests/functional/adapter/dbt_show/test_dbt_show.py
+++ b/tests/functional/adapter/dbt_show/test_dbt_show.py
@@ -1,4 +1,28 @@
+import pytest
 from dbt.tests.adapter.dbt_show.test_dbt_show import BaseShowSqlHeader, BaseShowLimit
+
+from dbt.tests.util import run_dbt
+
+model_with_json_struct = """
+    select *
+    from (
+        select
+  struct<
+    k array<
+        struct<c1 int64, c2 json>
+      >
+  >(
+    [
+      struct(
+        1 as c1,
+        to_json(struct(1 as a)) as c2
+      )
+    ]
+  )
+  as v
+    ) as model_limit_subq
+    limit 5
+    """
 
 
 class TestBigQueryShowLimit(BaseShowLimit):
@@ -7,3 +31,14 @@ class TestBigQueryShowLimit(BaseShowLimit):
 
 class TestBigQueryShowSqlHeader(BaseShowSqlHeader):
     pass
+
+
+class TestBigQueryShowSqlWorksWithJSONStruct:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "json_struct_model.sql": model_with_json_struct,
+        }
+
+    def test_sql_header(self, project):
+        run_dbt(["show", "--select", "json_struct_model"])


### PR DESCRIPTION
resolves #972
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

`dbt show --select` currently breaks when attempted on a `json` field because of [this bigquery python client issue](https://github.com/googleapis/python-bigquery/issues/1500)

### Solution

Patch as suggested by @dbeatty10 

```
# Override broken json deserializer for dbt show --inline
def _json_from_json(value, _):
    """NOOP string -> string coercion"""
    return json.loads(value)

bigquery._helpers._CELLDATA_FROM_JSON["JSON"] = _json_from_json
```

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc)
