### PR TITLE
Lower bound of `2.11.0` for `google-api-core`

### DIFF
--- a/.changes/unreleased/Fixes-20231025-131907.yaml
+++ b/.changes/unreleased/Fixes-20231025-131907.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Lower bound of `2.11.0` for `google-api-core`
+time: 2023-10-25T13:19:07.580826-06:00
+custom:
+  Author: gmyrianthous dbeatty10
+  Issue: "979"

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,9 @@ setup(
         "google-cloud-bigquery~=3.0",
         "google-cloud-storage~=2.4",
         "google-cloud-dataproc~=5.0",
+        # ----
+        # Expect compatibility with all new versions of these packages, so lower bounds only.
+        "google-api-core>=2.11.0",
     ],
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
resolves #979

### Problem

> we [import `POLLING_PREDICATE` from `google.api_core.future.polling` ](https://github.com/dbt-labs/dbt-bigquery/blob/6a3f45897f4e7ccd41de584d64605e7342dc75e0/dbt/adapters/bigquery/python_submissions.py#L4) but `google.api_core.future.polling.POLLING_PREDICATE` is available on `google-api-core` version `2.11.0`+. 


### Solution

> ensure that this version is enforced and create a pin

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] ~I have run~ @gmyrianthous ran this code in development and it appears to resolve the stated issue
- [x] Tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc)