### PR TITLE
Fix inline comments (--) on the last line of an incremental model (partition replacement)

### DIFF
--- a/.changes/unreleased/Fixes-20231105-125740.yaml
+++ b/.changes/unreleased/Fixes-20231105-125740.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix inline comments (--) on the last line of an incremental model
+time: 2023-11-05T12:57:40.289399+09:00
+custom:
+  Author: tnk-ysk
+  Issue: "896"

--- a/dbt/include/bigquery/macros/materializations/incremental_strategy/insert_overwrite.sql
+++ b/dbt/include/bigquery/macros/materializations/incremental_strategy/insert_overwrite.sql
@@ -70,7 +70,7 @@
             {{ wrap_with_time_ingestion_partitioning_sql(partition_by, sql, True) }}
           {%- else -%}
             {{sql}}
-          {%- endif -%}
+          {%- endif %}
 
         )
       {%- endset -%}

--- a/tests/functional/adapter/incremental/incremental_strategy_fixtures.py
+++ b/tests/functional/adapter/incremental/incremental_strategy_fixtures.py
@@ -133,6 +133,50 @@ where date_day >= _dbt_max_partition
 {% endif %}
 """.lstrip()
 
+overwrite_date_with_comment_at_end_sql = """
+{{
+    config(
+        materialized="incremental",
+        incremental_strategy='insert_overwrite',
+        cluster_by="id",
+        partition_by={
+            "field": "date_day",
+            "data_type": "date"
+        }
+    )
+}}
+
+
+with data as (
+
+    {% if not is_incremental() %}
+
+        select 1 as id, cast('2020-01-01' as date) as date_day union all
+        select 2 as id, cast('2020-01-01' as date) as date_day union all
+        select 3 as id, cast('2020-01-01' as date) as date_day union all
+        select 4 as id, cast('2020-01-01' as date) as date_day
+
+    {% else %}
+
+        -- we want to overwrite the 4 records in the 2020-01-01 partition
+        -- with the 2 records below, but add two more in the 2020-01-02 partition
+        select 10 as id, cast('2020-01-01' as date) as date_day union all
+        select 20 as id, cast('2020-01-01' as date) as date_day union all
+        select 30 as id, cast('2020-01-02' as date) as date_day union all
+        select 40 as id, cast('2020-01-02' as date) as date_day
+
+    {% endif %}
+
+)
+
+select * from data
+
+{% if is_incremental() %}
+where date_day >= _dbt_max_partition
+{% endif %}
+-- Test comment to prevent recurrence of https://github.com/dbt-labs/dbt-bigquery/issues/896
+""".lstrip()
+
 overwrite_day_sql = """
 {{
     config(

--- a/tests/functional/adapter/incremental/incremental_strategy_fixtures.py
+++ b/tests/functional/adapter/incremental/incremental_strategy_fixtures.py
@@ -133,50 +133,6 @@ where date_day >= _dbt_max_partition
 {% endif %}
 """.lstrip()
 
-overwrite_date_with_comment_at_end_sql = """
-{{
-    config(
-        materialized="incremental",
-        incremental_strategy='insert_overwrite',
-        cluster_by="id",
-        partition_by={
-            "field": "date_day",
-            "data_type": "date"
-        }
-    )
-}}
-
-
-with data as (
-
-    {% if not is_incremental() %}
-
-        select 1 as id, cast('2020-01-01' as date) as date_day union all
-        select 2 as id, cast('2020-01-01' as date) as date_day union all
-        select 3 as id, cast('2020-01-01' as date) as date_day union all
-        select 4 as id, cast('2020-01-01' as date) as date_day
-
-    {% else %}
-
-        -- we want to overwrite the 4 records in the 2020-01-01 partition
-        -- with the 2 records below, but add two more in the 2020-01-02 partition
-        select 10 as id, cast('2020-01-01' as date) as date_day union all
-        select 20 as id, cast('2020-01-01' as date) as date_day union all
-        select 30 as id, cast('2020-01-02' as date) as date_day union all
-        select 40 as id, cast('2020-01-02' as date) as date_day
-
-    {% endif %}
-
-)
-
-select * from data
-
-{% if is_incremental() %}
-where date_day >= _dbt_max_partition
-{% endif %}
--- Test comment to prevent recurrence of https://github.com/dbt-labs/dbt-bigquery/issues/896
-""".lstrip()
-
 overwrite_day_sql = """
 {{
     config(
@@ -350,6 +306,7 @@ select * from data
 {% if is_incremental() %}
 where date_day in ({{ config.get("partitions") | join(",") }})
 {% endif %}
+-- Test comment to prevent recurrence of https://github.com/dbt-labs/dbt-bigquery/issues/896
 """.lstrip()
 
 overwrite_range_sql = """

--- a/tests/functional/adapter/incremental/test_incremental_strategies.py
+++ b/tests/functional/adapter/incremental/test_incremental_strategies.py
@@ -18,7 +18,6 @@ from tests.functional.adapter.incremental.incremental_strategy_fixtures import (
     merge_range_sql,
     merge_time_sql,
     overwrite_date_sql,
-    overwrite_date_with_comment_at_end_sql,
     overwrite_day_sql,
     overwrite_day_with_copy_partitions_sql,
     overwrite_partitions_sql,
@@ -41,7 +40,6 @@ class TestBigQueryScripting(SeedConfigBase):
             "incremental_merge_range.sql": merge_range_sql,
             "incremental_merge_time.sql": merge_time_sql,
             "incremental_overwrite_date.sql": overwrite_date_sql,
-            "incremental_overwrite_date_with_comment_at_end.sql": overwrite_date_with_comment_at_end_sql,
             "incremental_overwrite_day.sql": overwrite_day_sql,
             "incremental_overwrite_day_with_copy_partitions.sql": overwrite_day_with_copy_partitions_sql,
             "incremental_overwrite_partitions.sql": overwrite_partitions_sql,
@@ -67,19 +65,15 @@ class TestBigQueryScripting(SeedConfigBase):
     def test__bigquery_assert_incremental_configurations_apply_the_right_strategy(self, project):
         run_dbt(["seed"])
         results = run_dbt()
-        assert len(results) == 12
+        assert len(results) == 11
 
         results = run_dbt()
-        assert len(results) == 12
+        assert len(results) == 11
         incremental_strategies = [
             ("incremental_merge_range", "merge_expected"),
             ("incremental_merge_time", "merge_expected"),
             ("incremental_overwrite_time", "incremental_overwrite_time_expected"),
             ("incremental_overwrite_date", "incremental_overwrite_date_expected"),
-            (
-                "incremental_overwrite_date_with_comment_at_end",
-                "incremental_overwrite_date_expected",
-            ),
             ("incremental_overwrite_partitions", "incremental_overwrite_date_expected"),
             ("incremental_overwrite_day", "incremental_overwrite_day_expected"),
             ("incremental_overwrite_range", "incremental_overwrite_range_expected"),

--- a/tests/functional/adapter/incremental/test_incremental_strategies.py
+++ b/tests/functional/adapter/incremental/test_incremental_strategies.py
@@ -18,6 +18,7 @@ from tests.functional.adapter.incremental.incremental_strategy_fixtures import (
     merge_range_sql,
     merge_time_sql,
     overwrite_date_sql,
+    overwrite_date_with_comment_at_end_sql,
     overwrite_day_sql,
     overwrite_day_with_copy_partitions_sql,
     overwrite_partitions_sql,
@@ -40,6 +41,7 @@ class TestBigQueryScripting(SeedConfigBase):
             "incremental_merge_range.sql": merge_range_sql,
             "incremental_merge_time.sql": merge_time_sql,
             "incremental_overwrite_date.sql": overwrite_date_sql,
+            "incremental_overwrite_date_with_comment_at_end.sql": overwrite_date_with_comment_at_end_sql,
             "incremental_overwrite_day.sql": overwrite_day_sql,
             "incremental_overwrite_day_with_copy_partitions.sql": overwrite_day_with_copy_partitions_sql,
             "incremental_overwrite_partitions.sql": overwrite_partitions_sql,
@@ -65,15 +67,16 @@ class TestBigQueryScripting(SeedConfigBase):
     def test__bigquery_assert_incremental_configurations_apply_the_right_strategy(self, project):
         run_dbt(["seed"])
         results = run_dbt()
-        assert len(results) == 11
+        assert len(results) == 12
 
         results = run_dbt()
-        assert len(results) == 11
+        assert len(results) == 12
         incremental_strategies = [
             ("incremental_merge_range", "merge_expected"),
             ("incremental_merge_time", "merge_expected"),
             ("incremental_overwrite_time", "incremental_overwrite_time_expected"),
             ("incremental_overwrite_date", "incremental_overwrite_date_expected"),
+            ("incremental_overwrite_date_with_comment_at_end", "incremental_overwrite_date_expected"),
             ("incremental_overwrite_partitions", "incremental_overwrite_date_expected"),
             ("incremental_overwrite_day", "incremental_overwrite_day_expected"),
             ("incremental_overwrite_range", "incremental_overwrite_range_expected"),

--- a/tests/functional/adapter/incremental/test_incremental_strategies.py
+++ b/tests/functional/adapter/incremental/test_incremental_strategies.py
@@ -76,7 +76,10 @@ class TestBigQueryScripting(SeedConfigBase):
             ("incremental_merge_time", "merge_expected"),
             ("incremental_overwrite_time", "incremental_overwrite_time_expected"),
             ("incremental_overwrite_date", "incremental_overwrite_date_expected"),
-            ("incremental_overwrite_date_with_comment_at_end", "incremental_overwrite_date_expected"),
+            (
+                "incremental_overwrite_date_with_comment_at_end",
+                "incremental_overwrite_date_expected",
+            ),
             ("incremental_overwrite_partitions", "incremental_overwrite_date_expected"),
             ("incremental_overwrite_day", "incremental_overwrite_day_expected"),
             ("incremental_overwrite_range", "incremental_overwrite_range_expected"),


### PR DESCRIPTION
resolves #896
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem
If an incremental model (with static partition replacement) has an inline SQL comment, this results in an invalid SQL statement.
<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution
Change so that there is a line break after the SQL.
~Test has not been added as it is expected to be added by https://github.com/dbt-labs/dbt-core/issues/8487~

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
