### PR TITLE
ADAP-972: Fix issue where materialized views were being mapped as tables in catalog queries

### DIFF
--- a/.changes/unreleased/Fixes-20231030-222134.yaml
+++ b/.changes/unreleased/Fixes-20231030-222134.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Assign the correct relation type to materialized views in catalog queries
+time: 2023-10-30T22:21:34.401675-04:00
+custom:
+  Author: mikealfare
+  Issue: "995"

--- a/tests/functional/adapter/catalog_tests/files.py
+++ b/tests/functional/adapter/catalog_tests/files.py
@@ -1,0 +1,33 @@
+MY_SEED = """
+id,value,record_valid_date
+1,100,2023-01-01 00:00:00
+2,200,2023-01-02 00:00:00
+3,300,2023-01-02 00:00:00
+""".strip()
+
+
+MY_TABLE = """
+{{ config(
+    materialized='table',
+) }}
+select *
+from {{ ref('my_seed') }}
+"""
+
+
+MY_VIEW = """
+{{ config(
+    materialized='view',
+) }}
+select *
+from {{ ref('my_seed') }}
+"""
+
+
+MY_MATERIALIZED_VIEW = """
+{{ config(
+    materialized='materialized_view',
+) }}
+select *
+from {{ ref('my_table') }}
+"""

--- a/tests/functional/adapter/catalog_tests/test_relation_types.py
+++ b/tests/functional/adapter/catalog_tests/test_relation_types.py
@@ -37,7 +37,7 @@ class TestCatalogRelationTypes:
         self, docs: CatalogArtifact, node_name: str, relation_type: str
     ):
         """
-        This test addresses: https://github.com/dbt-labs/dbt-core/issues/8864
+        This test addresses: https://github.com/dbt-labs/dbt-bigquery/issues/995
         """
         assert node_name in docs.nodes
         node = docs.nodes[node_name]

--- a/tests/functional/adapter/catalog_tests/test_relation_types.py
+++ b/tests/functional/adapter/catalog_tests/test_relation_types.py
@@ -1,0 +1,44 @@
+from dbt.contracts.results import CatalogArtifact
+from dbt.tests.util import run_dbt
+import pytest
+
+from tests.functional.adapter.catalog_tests import files
+
+
+class TestCatalogRelationTypes:
+    @pytest.fixture(scope="class", autouse=True)
+    def seeds(self):
+        return {"my_seed.csv": files.MY_SEED}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        yield {
+            "my_table.sql": files.MY_TABLE,
+            "my_view.sql": files.MY_VIEW,
+            "my_materialized_view.sql": files.MY_MATERIALIZED_VIEW,
+        }
+
+    @pytest.fixture(scope="class", autouse=True)
+    def docs(self, project):
+        run_dbt(["seed"])
+        run_dbt(["run"])
+        yield run_dbt(["docs", "generate"])
+
+    @pytest.mark.parametrize(
+        "node_name,relation_type",
+        [
+            ("seed.test.my_seed", "table"),
+            ("model.test.my_table", "table"),
+            ("model.test.my_view", "view"),
+            ("model.test.my_materialized_view", "materialized view"),
+        ],
+    )
+    def test_relation_types_populate_correctly(
+        self, docs: CatalogArtifact, node_name: str, relation_type: str
+    ):
+        """
+        This test addresses: https://github.com/dbt-labs/dbt-core/issues/8864
+        """
+        assert node_name in docs.nodes
+        node = docs.nodes[node_name]
+        assert node.metadata.type == relation_type


### PR DESCRIPTION
resolves #995, dbt-labs/dbt-core#8864

### Problem

Materialized views were being mapped as tables in catalog queries.

### Solution

- write a test demonstrating the issue
- update the catalog query to return the correct type

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
