### PR TITLE
Replace deprecated partitioning_type with time_partitioning.type_

### DIFF
--- a/.changes/unreleased/Under the Hood-20231102-174007.yaml
+++ b/.changes/unreleased/Under the Hood-20231102-174007.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Updated usage of deprecated `Table.time_partitioning` method to `Table.time_partitioning.type_`
+  as per BigQuery adapter recommendations.
+time: 2023-11-02T17:40:07.491202+01:00
+custom:
+  Author: jakuborlowski
+  Issue: N/A

--- a/dbt/adapters/bigquery/impl.py
+++ b/dbt/adapters/bigquery/impl.py
@@ -485,7 +485,7 @@ class BigQueryAdapter(BaseAdapter):
                 table.time_partitioning.field.lower() if table.time_partitioning.field else None
             )
 
-            table_granularity = table.partitioning_type
+            table_granularity = table.time_partitioning.type_
             conf_table_field = conf_partition.field
             return (
                 table_field == conf_table_field.lower()


### PR DESCRIPTION
### Problem

Using the deprecated partitioning_type from google.cloud.bigquery.table results in a PendingDeprecationWarning.

### Solution

Replaced the partitioning_type attribute with time_partitioning.type_ as advised by the deprecation warning.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
