### PR TITLE
Support agate Integer type, test with empty seed

### DIFF
--- a/.changes/unreleased/Fixes-20231107-100905.yaml
+++ b/.changes/unreleased/Fixes-20231107-100905.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Support agate Integer type, test with empty seed
+time: 2023-11-07T10:09:05.723451-05:00
+custom:
+  Author: gshank
+  Issue: "1003"

--- a/dbt/adapters/bigquery/impl.py
+++ b/dbt/adapters/bigquery/impl.py
@@ -325,6 +325,10 @@ class BigQueryAdapter(BaseAdapter):
         return "float64" if decimals else "int64"
 
     @classmethod
+    def convert_integer_type(cls, agate_table: agate.Table, col_idx: int) -> str:
+        return "int64"
+
+    @classmethod
     def convert_boolean_type(cls, agate_table: agate.Table, col_idx: int) -> str:
         return "bool"
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 # install latest changes in dbt-core
 # TODO: how to automate switching from develop to version branches?
-git+https://github.com/dbt-labs/dbt-core.git@8895-agate_integer_conversion#egg=dbt-core&subdirectory=core
-git+https://github.com/dbt-labs/dbt-core.git@8895-agate_integer_conversion#egg=dbt-tests-adapter&subdirectory=tests/adapter
+git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
+git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-tests-adapter&subdirectory=tests/adapter
 
 # if version 1.x or greater -> pin to major version
 # if version 0.x -> pin to minor

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 # install latest changes in dbt-core
 # TODO: how to automate switching from develop to version branches?
-git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
-git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-tests-adapter&subdirectory=tests/adapter
+git+https://github.com/dbt-labs/dbt-core.git@8895-agate_integer_conversion#egg=dbt-core&subdirectory=core
+git+https://github.com/dbt-labs/dbt-core.git@8895-agate_integer_conversion#egg=dbt-tests-adapter&subdirectory=tests/adapter
 
 # if version 1.x or greater -> pin to major version
 # if version 0.x -> pin to minor

--- a/tests/functional/adapter/test_simple_seed.py
+++ b/tests/functional/adapter/test_simple_seed.py
@@ -2,6 +2,7 @@ import pytest
 from dbt.tests.adapter.simple_seed.fixtures import macros__schema_test
 from dbt.tests.adapter.simple_seed.seeds import seeds__enabled_in_config_csv, seeds__tricky_csv
 from dbt.tests.adapter.simple_seed.test_seed import SeedConfigBase
+from dbt.tests.adapter.simple_seed.test_seed import BaseTestEmptySeed
 from dbt.tests.adapter.utils.base_utils import run_dbt
 
 
@@ -151,3 +152,7 @@ class TestSimpleSeedConfigs(SeedConfigBase):
             assert bq_table.labels
             assert bq_table.labels == self.table_labels()
             assert bq_table.expires
+
+
+class TestBigQueryEmptySeed(BaseTestEmptySeed):
+    pass

--- a/tests/unit/mock_adapter.py
+++ b/tests/unit/mock_adapter.py
@@ -55,6 +55,9 @@ def adapter_factory():
         def convert_number_type(self, *args, **kwargs):
             return self.responder.convert_number_type(*args, **kwargs)
 
+        def convert_integer_type(self, *args, **kwargs):
+            return self.responder.convert_integer_type(*args, **kwargs)
+
         def convert_boolean_type(self, *args, **kwargs):
             return self.responder.convert_boolean_type(*args, **kwargs)
 


### PR DESCRIPTION
resolves #1003


### Problem

dbt Core introduced an agate Integer type. This provides code to support it and a test for a bug constructing an empty seed.

### Solution

Add a "convert_integer_type" method to dbt/adapters/bigquery/impl.py

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
