### PR TITLE
fix: cast dataproc batch runtime props

### DIFF
--- a/.changes/unreleased/Features-20231107-165830.yaml
+++ b/.changes/unreleased/Features-20231107-165830.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add support for integers as dataproc batch runtime config properties
+time: 2023-11-07T16:58:30.065966-05:00
+custom:
+  Author: jimmyshah
+  Issue: "1001"

--- a/dbt/adapters/bigquery/python_submissions.py
+++ b/dbt/adapters/bigquery/python_submissions.py
@@ -47,7 +47,9 @@ class BaseDataProcHelper(PythonJobHelper):
             project=self.credential.execution_project,
             credentials=self.GoogleCredentials,
         )
-        self.gcs_location = "gs://{}/{}".format(self.credential.gcs_bucket, self.model_file_name)
+        self.gcs_location = "gs://{}/{}".format(
+            self.credential.gcs_bucket, self.model_file_name
+        )
 
         # set retry policy, default to timeout after 24 hours
         self.timeout = self.parsed_model["config"].get(
@@ -57,7 +59,9 @@ class BaseDataProcHelper(PythonJobHelper):
             predicate=POLLING_PREDICATE, maximum=10.0, timeout=self.timeout
         )
         self.client_options = ClientOptions(
-            api_endpoint="{}-dataproc.googleapis.com:443".format(self.credential.dataproc_region)
+            api_endpoint="{}-dataproc.googleapis.com:443".format(
+                self.credential.dataproc_region
+            )
         )
         self.job_client = self._get_job_client()
 

--- a/dbt/adapters/bigquery/python_submissions.py
+++ b/dbt/adapters/bigquery/python_submissions.py
@@ -183,5 +183,5 @@ class ServerlessDataProcHelper(BaseDataProcHelper):
             batch = update_batch_from_config(self.credential.dataproc_batch, batch)
             if batch.runtime_config.properties:
                 for key, val in batch.runtime_config.properties.items():
-                    batch.runtime_config.properties[key] = str(val)
+                    batch.runtime_config.properties[key] = str(val) 
         return batch

--- a/dbt/adapters/bigquery/python_submissions.py
+++ b/dbt/adapters/bigquery/python_submissions.py
@@ -176,7 +176,7 @@ class ServerlessDataProcHelper(BaseDataProcHelper):
                 )
             }
         )
-        # Apply the defaults
+        # Apply defaults
         batch.pyspark_batch.main_python_file_uri = self.gcs_location
         jar_file_uri = self.parsed_model["config"].get(
             "jar_file_uri",

--- a/dbt/adapters/bigquery/python_submissions.py
+++ b/dbt/adapters/bigquery/python_submissions.py
@@ -47,9 +47,7 @@ class BaseDataProcHelper(PythonJobHelper):
             project=self.credential.execution_project,
             credentials=self.GoogleCredentials,
         )
-        self.gcs_location = "gs://{}/{}".format(
-            self.credential.gcs_bucket, self.model_file_name
-        )
+        self.gcs_location = "gs://{}/{}".format(self.credential.gcs_bucket, self.model_file_name)
 
         # set retry policy, default to timeout after 24 hours
         self.timeout = self.parsed_model["config"].get(
@@ -59,9 +57,7 @@ class BaseDataProcHelper(PythonJobHelper):
             predicate=POLLING_PREDICATE, maximum=10.0, timeout=self.timeout
         )
         self.client_options = ClientOptions(
-            api_endpoint="{}-dataproc.googleapis.com:443".format(
-                self.credential.dataproc_region
-            )
+            api_endpoint="{}-dataproc.googleapis.com:443".format(self.credential.dataproc_region)
         )
         self.job_client = self._get_job_client()
 
@@ -189,5 +185,5 @@ class ServerlessDataProcHelper(BaseDataProcHelper):
             batch = update_batch_from_config(self.credential.dataproc_batch, batch)
             if batch.runtime_config.properties:
                 for key, val in batch.runtime_config.properties.items():
-                    batch.runtime_config.properties[key] = str(val) 
+                    batch.runtime_config.properties[key] = str(val)
         return batch

--- a/dbt/adapters/bigquery/python_submissions.py
+++ b/dbt/adapters/bigquery/python_submissions.py
@@ -176,7 +176,7 @@ class ServerlessDataProcHelper(BaseDataProcHelper):
                 )
             }
         )
-        # Apply defaults
+        # Apply the defaults
         batch.pyspark_batch.main_python_file_uri = self.gcs_location
         jar_file_uri = self.parsed_model["config"].get(
             "jar_file_uri",


### PR DESCRIPTION
resolves #1001 

### Problem
There is a bug currently that requires `runtime_config` `properties` values to be strings. As a result, integer values need quotes around them in the yml files, which is awkward.

With this PR, values are cast as strings, so that the properties can be set in a more expected way.

[ADAP-1007]


### Solution
In `_configure_batch()`, I added a check for `runtime_config.properties`. If they exist, I iterate through the dictionary to cast the values as strings. Changing this part of the code was suggested as an option in #1001. 

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX


[ADAP-1007]: https://dbtlabs.atlassian.net/browse/ADAP-1007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ