### PR TITLE
ADAP-1017: Fix configuration change monitoring for scenarios with no changes

### DIFF
--- a/.changes/unreleased/Fixes-20231107-174352.yaml
+++ b/.changes/unreleased/Fixes-20231107-174352.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Fixed issue where materialized views were failing on re-run with minimal config
+  parameters
+time: 2023-11-07T17:43:52.972135-05:00
+custom:
+  Author: "mikealfare"
+  Issue: "1007"

--- a/dbt/adapters/bigquery/relation.py
+++ b/dbt/adapters/bigquery/relation.py
@@ -84,9 +84,10 @@ class BigQueryRelation(BaseRelation):
             )
 
         if new_materialized_view.partition != existing_materialized_view.partition:
+            # the existing PartitionConfig is not hashable, but since we need to do
+            # a full refresh either way, we don't need to provide a context
             config_change_collection.partition = BigQueryPartitionConfigChange(
                 action=RelationConfigChangeAction.alter,
-                context=new_materialized_view.partition,
             )
 
         if new_materialized_view.cluster != existing_materialized_view.cluster:

--- a/dbt/adapters/bigquery/relation.py
+++ b/dbt/adapters/bigquery/relation.py
@@ -95,7 +95,7 @@ class BigQueryRelation(BaseRelation):
                 context=new_materialized_view.cluster,
             )
 
-        if config_change_collection:
+        if config_change_collection.has_changes:
             return config_change_collection
         return None
 

--- a/dbt/adapters/bigquery/relation_configs/_partition.py
+++ b/dbt/adapters/bigquery/relation_configs/_partition.py
@@ -152,7 +152,7 @@ class PartitionConfig(dbtClassMixin):
 
 @dataclass(frozen=True, eq=True, unsafe_hash=True)
 class BigQueryPartitionConfigChange(RelationConfigChange):
-    context: Optional[PartitionConfig]
+    context: Optional[Any] = None
 
     @property
     def requires_full_refresh(self) -> bool:

--- a/tests/functional/adapter/materialized_view_tests/_files.py
+++ b/tests/functional/adapter/materialized_view_tests/_files.py
@@ -67,3 +67,14 @@ select
     record_valid_date
 from {{ ref('my_seed') }}
 """
+
+
+MY_MINIMAL_MATERIALIZED_VIEW = """
+{{
+  config(
+    materialized = 'materialized_view',
+    )
+}}
+
+select * from {{ ref('my_seed') }}
+"""


### PR DESCRIPTION
resolves #1007

### Problem

Users cannot recreate a materialized view if it does not have any changes. The configuration change collection is not being recognized as an empty set of changes.

### Solution

The check currently looks for the existence of the config change collection instead of whether it has any changes. Update the check to look for the existence of changes instead of the object itself.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
