### PR TITLE
Primary and foreign key constraints are not enforced in BigQuery

### DIFF
--- a/.changes/unreleased/Under the Hood-20231116-062142.yaml
+++ b/.changes/unreleased/Under the Hood-20231116-062142.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Primary and foreign key constraints are not enforced in BigQuery
+time: 2023-11-16T06:21:42.935367-08:00
+custom:
+  Author: dbeatty10
+  Issue: "1018"

--- a/dbt/adapters/bigquery/impl.py
+++ b/dbt/adapters/bigquery/impl.py
@@ -112,8 +112,8 @@ class BigQueryAdapter(BaseAdapter):
         ConstraintType.check: ConstraintSupport.NOT_SUPPORTED,
         ConstraintType.not_null: ConstraintSupport.ENFORCED,
         ConstraintType.unique: ConstraintSupport.NOT_SUPPORTED,
-        ConstraintType.primary_key: ConstraintSupport.ENFORCED,
-        ConstraintType.foreign_key: ConstraintSupport.ENFORCED,
+        ConstraintType.primary_key: ConstraintSupport.NOT_ENFORCED,
+        ConstraintType.foreign_key: ConstraintSupport.NOT_ENFORCED,
     }
 
     def __init__(self, config) -> None:


### PR DESCRIPTION
resolves #1018
https://github.com/dbt-labs/docs.getdbt.com/pull/4419

### Problem

The source code says [here](https://github.com/dbt-labs/dbt-bigquery/blob/64e042a2349f17342f7af96d559e4e3a5138a49e/dbt/adapters/bigquery/impl.py#L115-L116) that `primary_key` and `foreign_key` are enforced.

But as noted in https://github.com/dbt-labs/docs.getdbt.com/pull/4419, they are supported, but **_not_** enforced.

### Solution

Update the `CONSTRAINT_SUPPORT` to reflect what the BigQuery docs say [here](https://cloud.google.com/blog/products/data-analytics/join-optimizations-with-bigquery-primary-and-foreign-keys) and [here](https://cloud.google.com/bigquery/docs/information-schema-table-constraints).
 
### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR is relying on pre-existing tests for this feature
- [x] This PR has no interface changes
- [x] This PR has an associated docs update in [docs.getdbt.com #4419](https://github.com/dbt-labs/docs.getdbt.com/pull/4419)
