### PR TITLE
add tests for --empty flag

### DIFF
--- a/.changes/unreleased/Under the Hood-20231117-121214.yaml
+++ b/.changes/unreleased/Under the Hood-20231117-121214.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Add tests for --empty flag
+time: 2023-11-17T12:12:14.643365-05:00
+custom:
+  Author: michelleark
+  Issue: "1029"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 # install latest changes in dbt-core
 # TODO: how to automate switching from develop to version branches?
-git+https://github.com/dbt-labs/dbt-core.git@dry-run-flag#egg=dbt-core&subdirectory=core
-git+https://github.com/dbt-labs/dbt-core.git@dry-run-flag#egg=dbt-tests-adapter&subdirectory=tests/adapter
+git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
+git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-tests-adapter&subdirectory=tests/adapter
 
 # if version 1.x or greater -> pin to major version
 # if version 0.x -> pin to minor

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 # install latest changes in dbt-core
 # TODO: how to automate switching from develop to version branches?
-git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
-git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-tests-adapter&subdirectory=tests/adapter
+git+https://github.com/dbt-labs/dbt-core.git@dry-run-flag#egg=dbt-core&subdirectory=core
+git+https://github.com/dbt-labs/dbt-core.git@dry-run-flag#egg=dbt-tests-adapter&subdirectory=tests/adapter
 
 # if version 1.x or greater -> pin to major version
 # if version 0.x -> pin to minor

--- a/tests/functional/adapter/empty/test_empty.py
+++ b/tests/functional/adapter/empty/test_empty.py
@@ -1,0 +1,5 @@
+from dbt.tests.adapter.empty.test_empty import BaseTestEmpty
+
+
+class TestBigQueryEmpty(BaseTestEmpty):
+    pass


### PR DESCRIPTION
resolves #1029
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/# N/A

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

https://github.com/dbt-labs/dbt-core/pull/8971 introduced a new `--empty` flag that required implementation changes to the BaseRelation.

### Solution

Add tests in dbt-bigquery to ensure expected behaviour of the new `--empty` flag when running with dbt-bigquery.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
