### PR TITLE
retry wait for result independently from job creation

### DIFF
--- a/.changes/unreleased/Fixes-20231206-172009.yaml
+++ b/.changes/unreleased/Fixes-20231206-172009.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: retry wait for result independently from job creation
+time: 2023-12-06T17:20:09.264805+01:00
+custom:
+  Author: Kayrnt
+  Issue: "1045"


### PR DESCRIPTION
resolves #1045

### Problem

When an error occurs either on job creation or waiting for the result, the job creation + wait result step is retried.
Then the underlying wait for result step might "fail" (as it's polling for the result every X seconds) and a network error... can lead to retry the whole job.
If the job isn't idempotent => it leads to a bug (what happened for a coworker).
if the job is idempotent => you likely wasted slot time/BQ resources.

### Solution

To solve that, let's split the step in 2 functions that are both retried on their own so that we retry accessing the running job.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
