### PR TITLE
Dataproc Job options in model config

### DIFF
--- a/dbt/adapters/bigquery/python_submissions.py
+++ b/dbt/adapters/bigquery/python_submissions.py
@@ -103,6 +103,14 @@ class ClusterDataprocHelper(BaseDataProcHelper):
             "placement": {"cluster_name": self._get_cluster_name()},
             "pyspark_job": {
                 "main_python_file_uri": self.gcs_location,
+                "archive_uris": self.parsed_model["config"].get(
+                    "dataproc_archive_uris",
+                    [],
+                ),
+                "properties": self.parsed_model["config"].get(
+                    "dataproc_properties",
+                    {},
+                ),
             },
         }
         operation = self.job_client.submit_job_as_operation(  # type: ignore

--- a/dbt/adapters/bigquery/python_submissions.py
+++ b/dbt/adapters/bigquery/python_submissions.py
@@ -102,17 +102,11 @@ class ClusterDataprocHelper(BaseDataProcHelper):
         job = {
             "placement": {"cluster_name": self._get_cluster_name()},
             "pyspark_job": {
-                "main_python_file_uri": self.gcs_location,
-                "archive_uris": self.parsed_model["config"].get(
-                    "dataproc_archive_uris",
-                    [],
-                ),
-                "properties": self.parsed_model["config"].get(
-                    "dataproc_properties",
-                    {},
-                ),
+                "main_python_file_uri": self.gcs_location
             },
         }
+        job["pyspark_job"].update(self.parsed_model["config"].get("dataproc_pyspark_job", {}))
+        
         operation = self.job_client.submit_job_as_operation(  # type: ignore
             request={
                 "project_id": self.credential.execution_project,


### PR DESCRIPTION
### Problem

For a given model, it was required to further configure the pyspark job. We are adding config properties to do so.

### Solution

In the `_submit_dataproc_job` method of the `ClusterDataprocHelper` we are reading optional `dataproc_pyspark_job`  field. This field is an object with the following [schema](https://cloud.google.com/dataproc/docs/reference/rest/v1/PySparkJob).

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
