### PR TITLE
 Implementation of metadata-based freshness

### DIFF
--- a/.changes/unreleased/Features-20231218-155409.yaml
+++ b/.changes/unreleased/Features-20231218-155409.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add support for checking table-last-modified by metadata
+time: 2023-12-18T15:54:09.69635-05:00
+custom:
+  Author: mikealfare
+  Issue: "938"

--- a/dbt/adapters/bigquery/impl.py
+++ b/dbt/adapters/bigquery/impl.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
+from datetime import datetime
 import json
 import threading
 import time
-from typing import Any, Dict, List, Optional, Type, Set, Union
+from typing import Any, Dict, List, Optional, Tuple, Type, Set, Union
 
 import agate
 from dbt import ui  # type: ignore
@@ -16,6 +17,7 @@ from dbt.adapters.base import (  # type: ignore
     SchemaSearchMap,
     available,
 )
+from dbt.adapters.base.impl import FreshnessResponse
 from dbt.adapters.cache import _make_ref_key_dict  # type: ignore
 from dbt.adapters.capability import CapabilityDict, CapabilitySupport, Support, Capability
 import dbt.clients.agate_helper
@@ -35,6 +37,7 @@ import google.oauth2
 import google.cloud.bigquery
 from google.cloud.bigquery import AccessEntry, SchemaField, Table as BigQueryTable
 import google.cloud.exceptions
+import pytz
 
 from dbt.adapters.bigquery import BigQueryColumn, BigQueryConnectionManager
 from dbt.adapters.bigquery.column import get_nested_column_data_types
@@ -710,6 +713,26 @@ class BigQueryAdapter(BaseAdapter):
                     )
                 )
         return result
+
+    def calculate_freshness_from_metadata(
+        self,
+        source: BaseRelation,
+        manifest: Optional[Manifest] = None,
+    ) -> Tuple[Optional[AdapterResponse], FreshnessResponse]:
+        conn = self.connections.get_thread_connection()
+        client: google.cloud.bigquery.Client = conn.handle
+
+        table_ref = self.get_table_ref_from_relation(source)
+        table = client.get_table(table_ref)
+        snapshot = datetime.now(tz=pytz.UTC)
+
+        freshness = FreshnessResponse(
+            max_loaded_at=table.modified,
+            snapshotted_at=snapshot,
+            age=(snapshot - table.modified).total_seconds(),
+        )
+
+        return None, freshness
 
     @available.parse(lambda *a, **k: {})
     def get_common_options(

--- a/dbt/adapters/bigquery/impl.py
+++ b/dbt/adapters/bigquery/impl.py
@@ -17,6 +17,7 @@ from dbt.adapters.base import (  # type: ignore
     available,
 )
 from dbt.adapters.cache import _make_ref_key_dict  # type: ignore
+from dbt.adapters.capability import CapabilityDict, CapabilitySupport, Support, Capability
 import dbt.clients.agate_helper
 from dbt.contracts.connection import AdapterResponse
 from dbt.contracts.graph.manifest import Manifest
@@ -115,6 +116,12 @@ class BigQueryAdapter(BaseAdapter):
         ConstraintType.primary_key: ConstraintSupport.ENFORCED,
         ConstraintType.foreign_key: ConstraintSupport.ENFORCED,
     }
+
+    _capabilities: CapabilityDict = CapabilityDict(
+        {
+            Capability.TableLastModifiedMetadata: CapabilitySupport(support=Support.Full),
+        }
+    )
 
     def __init__(self, config) -> None:
         super().__init__(config)

--- a/tests/boundary/test_bigquery_sdk.py
+++ b/tests/boundary/test_bigquery_sdk.py
@@ -1,0 +1,20 @@
+import pytest
+
+from dbt.tests.util import get_connection
+from google.cloud.bigquery import Client, DatasetReference, TableReference
+from google.api_core.exceptions import NotFound
+
+
+class TestBigQuerySDK:
+    """
+    TODO: replace dbt project methods with direct connection instantiation
+    """
+
+    @pytest.mark.parametrize("table_name", ["this_table_does_not_exist"])
+    def test_get_table_does_not_exist(self, project, table_name):
+        with get_connection(project.adapter) as conn:
+            client: Client = conn.handle
+            dataset_ref = DatasetReference(project.database, project.test_schema)
+            table_ref = TableReference(dataset_ref, table_name)
+            with pytest.raises(NotFound):
+                client.get_table(table_ref)

--- a/tests/boundary/test_bigquery_sdk.py
+++ b/tests/boundary/test_bigquery_sdk.py
@@ -5,16 +5,14 @@ from google.cloud.bigquery import Client, DatasetReference, TableReference
 from google.api_core.exceptions import NotFound
 
 
-class TestBigQuerySDK:
+@pytest.mark.parametrize("table_name", ["this_table_does_not_exist"])
+def test_get_table_does_not_exist(project, table_name):
     """
     TODO: replace dbt project methods with direct connection instantiation
     """
-
-    @pytest.mark.parametrize("table_name", ["this_table_does_not_exist"])
-    def test_get_table_does_not_exist(self, project, table_name):
-        with get_connection(project.adapter) as conn:
-            client: Client = conn.handle
-            dataset_ref = DatasetReference(project.database, project.test_schema)
-            table_ref = TableReference(dataset_ref, table_name)
-            with pytest.raises(NotFound):
-                client.get_table(table_ref)
+    with get_connection(project.adapter) as conn:
+        client: Client = conn.handle
+        dataset_ref = DatasetReference(project.database, project.test_schema)
+        table_ref = TableReference(dataset_ref, table_name)
+        with pytest.raises(NotFound):
+            client.get_table(table_ref)

--- a/tests/functional/adapter/sources_freshness_tests/files.py
+++ b/tests/functional/adapter/sources_freshness_tests/files.py
@@ -1,0 +1,23 @@
+SCHEMA_YML = """version: 2
+sources:
+  - name: test_source
+    freshness:
+      warn_after: {count: 10, period: hour}
+      error_after: {count: 1, period: day}
+    schema: "{{ env_var('DBT_GET_LAST_RELATION_TEST_SCHEMA') }}"
+    tables:
+      - name: test_source
+"""
+
+SEED_TEST_SOURCE_CSV = """
+id,name
+1,Martin
+2,Jeter
+3,Ruth
+4,Gehrig
+5,DiMaggio
+6,Torre
+7,Mantle
+8,Berra
+9,Maris
+""".strip()

--- a/tests/functional/adapter/sources_freshness_tests/test_get_relation_last_modified.py
+++ b/tests/functional/adapter/sources_freshness_tests/test_get_relation_last_modified.py
@@ -23,7 +23,7 @@ class TestGetLastRelationModified:
         yield
         del os.environ["DBT_GET_LAST_RELATION_TEST_SCHEMA"]
 
-    def test_get_last_relation_modified(self, project, setup):
+    def test_get_last_relation_modified(self, project):
         results = run_dbt(["source", "freshness"])
         assert len(results) == 1
         result = results[0]

--- a/tests/functional/adapter/sources_freshness_tests/test_get_relation_last_modified.py
+++ b/tests/functional/adapter/sources_freshness_tests/test_get_relation_last_modified.py
@@ -1,0 +1,30 @@
+import os
+import pytest
+
+from dbt.tests.util import run_dbt
+
+from tests.functional.adapter.sources_freshness_tests import files
+
+
+class TestGetLastRelationModified:
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {"test_source.csv": files.SEED_TEST_SOURCE_CSV}
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"schema.yml": files.SCHEMA_YML}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def setup(self, project):
+        # we need the schema name for the sources section
+        os.environ["DBT_GET_LAST_RELATION_TEST_SCHEMA"] = project.test_schema
+        run_dbt(["seed"])
+        yield
+        del os.environ["DBT_GET_LAST_RELATION_TEST_SCHEMA"]
+
+    def test_get_last_relation_modified(self, project, setup):
+        results = run_dbt(["source", "freshness"])
+        assert len(results) == 1
+        result = results[0]
+        assert result.status == "pass"


### PR DESCRIPTION
resolves #938

### Problem

The current implementation of source freshness requires querying the data and requires the user provide a datetime field. This is slower and more expensive than it should be. It doesn't scale across multiple models. And some models do not have an appropriate datetime field.

### Solution

Use source metadata where available.

NOTE: We are releasing to `1.7.latest` first, which is unusual. This PR is a set of cherry picks from #1060. The latter will be updated and merged post adapter/core split work.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
