### PR TITLE
Fix null column index issue during `dbt docs generate` for external tables

### DIFF
--- a/.changes/unreleased/Fixes-20240201-145323.yaml
+++ b/.changes/unreleased/Fixes-20240201-145323.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix null column index issue during `dbt docs generate` for external tables
+time: 2024-02-01T14:53:23.434624-05:00
+custom:
+  Author: mikealfare
+  Issue: "1079"

--- a/dbt/include/bigquery/macros/catalog/catalog.sql
+++ b/dbt/include/bigquery/macros/catalog/catalog.sql
@@ -121,10 +121,12 @@
         end as table_name,
         tables.table_type,
         tables.table_comment,
-        columns.column_name,
-        columns.column_index,
-        columns.column_type,
-        columns.column_comment,
+        -- coalesce column metadata fields to ensure they are non-null for catalog generation
+        -- external table columns are not present in COLUMN_FIELD_PATHS
+        coalesce(columns.column_name, '<unknown>') as column_name,
+        coalesce(columns.column_index, 1) as column_index,
+        coalesce(columns.column_type, '<unknown>') as column_type,
+        coalesce(columns.column_comment, '') as column_comment,
 
         'Shard count' as `stats__date_shards__label`,
         table_stats.shard_count as `stats__date_shards__value`,


### PR DESCRIPTION
resolves #1079

### Problem

External tables don't show up in `COLUMN_FIELD_PATHS` metadata. When generating the catalog, these columns were returning null values for external tables. `dbt docs generate` does not account for null values for these fields, in particular for the column index.

### Solution

Coalesce the queried values with default values:
- column_name: `'<unknown>'`
- column_index: `1`
- column_type: `'<unknown>'`
- column_comment: `''`

The `'<unknown>'` values align with the previous implementation, as does the `1`. In the previous implementation, this was implicit, as it was calculated as a `row_number` across null fields. In this implementation, it's explicitly `1`, as there is really only one field, "the data". The column comment in the original implementation was null in this scenario; this is an attempt to avoid such an error with this field in the future.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX