### PR TITLE
Update BigQuery console job link log level from debug to info

### DIFF
--- a/dbt/adapters/bigquery/connections.py
+++ b/dbt/adapters/bigquery/connections.py
@@ -734,7 +734,7 @@ class BigQueryConnectionManager(BaseConnectionManager):
             and query_job.job_id is not None
             and query_job.project is not None
         ):
-            logger.debug(
+            logger.info(
                 self._bq_job_link(query_job.location, query_job.project, query_job.job_id)
             )
 


### PR DESCRIPTION
resolves #1136

### Problem

The BigQuery console job link is perhaps the most important log needed for troubleshooting issues with projects that orchestrate data pipelines on the cloud (e.g. Airflow). For those projects, especially the larger ones, debug-level logs are extremely verbose and massive (especially with full parse), so it would be useful to get the console job link at the info level.

### Solution

Changes the log level from `debug` to `info`.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
