### PR TITLE
Add Bigquery internal build process workflow 

### DIFF
--- a/.changes/unreleased/Features-20240318-032256.yaml
+++ b/.changes/unreleased/Features-20240318-032256.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add new workflow for internal patch releases
+time: 2024-03-18T03:22:56.037781-07:00
+custom:
+  Author: versusfacit
+  Issue: "38"

--- a/.github/workflows/release-internal.yml
+++ b/.github/workflows/release-internal.yml
@@ -1,0 +1,64 @@
+name: Release internal patch
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_number:
+        description: "The release version number (i.e. 1.0.0b1)"
+        type: string
+        required: true
+      sha:
+        description: "The sha to use (leave empty to use latest on main)"
+        type: string
+        required: false
+      package_test_command:
+        description: "Package test command"
+        type: string
+        default: "python -c \"import dbt.adapters.bigquery\""
+        required: true
+      dbms_name:
+        description: "The name of the warehouse the adapter connects to."
+        type: string
+        default: "bigquery"
+        required: true
+  workflow_call:
+    inputs:
+      version_number:
+        description: "The release version number (i.e. 1.0.0b1)"
+        type: string
+        required: true
+      sha:
+        description: "The sha to use (leave empty to use latest on main)"
+        type: string
+        required: false
+      package_test_command:
+        description: "Package test command"
+        type: string
+        default: "python -c \"import dbt.adapters.bigquery\""
+        required: true
+      dbms_name:
+        description: "The name of the warehouse the adapter connects to."
+        type: string
+        default: "bigquery"
+        required: true
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  PYTHON_TARGET_VERSION: 3.11
+
+jobs:
+  invoke-reusable-workflow:
+    name: Build and Release Internally
+
+    uses: VersusFacit/dbt-release/.github/workflows/internal-archive-release.yml@main
+
+    with:
+      version_number: ${{ inputs.version_number }}
+      package_test_command: ${{ inputs.package_test_command }}
+      dbms_name: ${{ inputs.dbms_name }}
+      sha: ${{ inputs.sha }}
+
+    secrets: inherit


### PR DESCRIPTION
resolves 38 of epic

This PR adds a workflow file for bigquery testing. It is based on [the already working redshift one](https://github.com/dbt-labs/dbt-redshift/pull/732). I assume there will be some quirks to work out. Also, we'll need to add aws secrets.