### PR TITLE
Add `pandas` extra for `google-cloud-bigquery` to pick up missing `pyarrow`

### DIFF
--- a/.changes/unreleased/Fixes-20240327-210249.yaml
+++ b/.changes/unreleased/Fixes-20240327-210249.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Add `pandas` extra for `google-cloud-bigquery` to pick up missing `pyarrow`
+  dependency
+time: 2024-03-27T21:02:49.619691-04:00
+custom:
+  Author: mikealfare
+  Issue: "1152"

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
         "dbt-common>=0.1.0a1,<2.0",
         "dbt-adapters>=0.1.0a1,<2.0",
         # 3.20 introduced pyarrow>=3.0 under the `pandas` extra
-        "google-cloud-bigquery[pandas]>=3.0",
+        "google-cloud-bigquery[pandas]>=3.0,<4.0",
         "google-cloud-storage~=2.4",
         "google-cloud-dataproc~=5.0",
         # ----

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,8 @@ setup(
     install_requires=[
         "dbt-common>=0.1.0a1,<2.0",
         "dbt-adapters>=0.1.0a1,<2.0",
-        "google-cloud-bigquery~=3.0",
+        # 3.20 introduced pyarrow>=3.0 under the `pandas` extra
+        "google-cloud-bigquery[pandas]>=3.0",
         "google-cloud-storage~=2.4",
         "google-cloud-dataproc~=5.0",
         # ----


### PR DESCRIPTION
resolves #1152

### Problem

`google-cloud-bigquery==3.20` added `pyarrow>=3.0` as a dependency for the `pandas` extra and we are not declaring the `pandas` extra. Either we are using functionality that requires the `pandas` extra and were not aware or this is a required dependency and not an extra dependency.

### Solution

Install `google-cloud-bigquery[pandas]>=3.0,<4.0`

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
