### PR TITLE
lazy load `agate`

### DIFF
--- a/.changes/unreleased/Under the Hood-20240331-101418.yaml
+++ b/.changes/unreleased/Under the Hood-20240331-101418.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Lazy load `agate`
+time: 2024-03-31T10:14:18.260074-04:00
+custom:
+  Author: dwreeves
+  Issue: "1162"

--- a/dbt/adapters/bigquery/relation_configs/_base.py
+++ b/dbt/adapters/bigquery/relation_configs/_base.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
-from typing import Optional, Dict
+from typing import Optional, Dict, TYPE_CHECKING
 
-import agate
 from dbt.adapters.base.relation import Policy
 from dbt.adapters.relation_configs import RelationConfigBase
 from google.cloud.bigquery import Table as BigQueryTable
@@ -12,6 +11,9 @@ from dbt.adapters.bigquery.relation_configs._policies import (
     BigQueryQuotePolicy,
 )
 from dbt.adapters.contracts.relation import ComponentName, RelationConfig
+
+if TYPE_CHECKING:
+    import agate
 
 
 @dataclass(frozen=True, eq=True, unsafe_hash=True)
@@ -55,8 +57,10 @@ class BigQueryBaseRelationConfig(RelationConfigBase):
         return None
 
     @classmethod
-    def _get_first_row(cls, results: agate.Table) -> agate.Row:
+    def _get_first_row(cls, results: "agate.Table") -> "agate.Row":
         try:
             return results.rows[0]
         except IndexError:
+            import agate
+
             return agate.Row(values=set())


### PR DESCRIPTION
resolves #1162

### Problem

TLDR: lazy-loading `agate` speeds up the load time of dbt by about 3.5%. Most instances of `agate` are unnecessary as dbt only uses it in a select few situations, and most instances of `agate` can be placed behind `TYPE_CHECKING`.

Already implemented in `dbt-adapters` and `dbt-core`.

- https://github.com/dbt-labs/dbt-adapters/pull/126
- https://github.com/dbt-labs/dbt-core/pull/9744

Check performed (should return empty list):

```python
import sys
import dbt.adapters.bigquery.impl
print([i for i in sys.modules if "agate" in i])
```

### Solution

`from typing import TYPE_CHECKING`

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
