### PR TITLE
change format of hours_to_expiration for materialized view 

### DIFF
--- a/dbt/adapters/bigquery/relation_configs/_options.py
+++ b/dbt/adapters/bigquery/relation_configs/_options.py
@@ -126,7 +126,7 @@ class BigQueryOptionsConfig(BigQueryBaseRelationConfig):
             "hours_to_expiration"
         ):  # type: ignore
             config_dict.update(
-                {"expiration_timestamp": datetime.now() + timedelta(hours=hours_to_expiration)}
+                {"expiration_timestamp": f"TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL {hours_to_expiration} hour)"}
             )
         if not relation_config.config.persist_docs:  # type: ignore
             del config_dict["description"]


### PR DESCRIPTION
 to instead of using timestamp use a sql string.

Resolve #1173 

### Problem

Incorrect format of string missing "" around timestamp

### Solution

change format to similare format solution used in impl.py 
`expiration = f'TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL {config.get("hours_to_expiration")} hour)'`

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
