### PR TITLE
fix Core version bump in setup.py during release

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -32,6 +32,4 @@ first_value = 1
 
 [bumpversion:part:nightly]
 
-[bumpversion:file:setup.py]
-
 [bumpversion:file:dbt/adapters/bigquery/__version__.py]

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ def _dbt_bigquery_version() -> str:
 
 
 package_name = "dbt-bigquery"
-package_version = "1.9.0a1"
 description = """The BigQuery adapter plugin for dbt"""
 
 setup(

--- a/tests/functional/adapter/test_grant_access_to.py
+++ b/tests/functional/adapter/test_grant_access_to.py
@@ -87,15 +87,6 @@ class TestAccessGrantSucceeds:
 
 
 class TestAccessGrantFails:
-    @pytest.fixture(scope="class", autouse=True)
-    def setup(self, project):
-        with project.adapter.connection_named("__test_grants"):
-            relation = project.adapter.Relation.create(
-                database=project.database, schema=f"{project.test_schema}_seeds"
-            )
-            yield relation
-            project.adapter.drop_relation(relation)
-
     @pytest.fixture(scope="class")
     def models(self):
         return {

--- a/tests/functional/adapter/test_grant_access_to.py
+++ b/tests/functional/adapter/test_grant_access_to.py
@@ -95,6 +95,7 @@ class TestAccessGrantFails:
             )
             yield relation
             project.adapter.drop_relation(relation)
+
     @pytest.fixture(scope="class")
     def models(self):
         return {

--- a/tests/functional/adapter/test_grant_access_to.py
+++ b/tests/functional/adapter/test_grant_access_to.py
@@ -87,6 +87,14 @@ class TestAccessGrantSucceeds:
 
 
 class TestAccessGrantFails:
+    @pytest.fixture(scope="class", autouse=True)
+    def setup(self, project):
+        with project.adapter.connection_named("__test_grants"):
+            relation = project.adapter.Relation.create(
+                database=project.database, schema=f"{project.test_schema}_seeds"
+            )
+            yield relation
+            project.adapter.drop_relation(relation)
     @pytest.fixture(scope="class")
     def models(self):
         return {


### PR DESCRIPTION
remove duplicate package_version and avoid bumping dbt-core version

resolves #
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
