### PR TITLE
Forward-port fix from #1085

### DIFF
--- a/.changes/unreleased/Fixes-20240201-145323.yaml
+++ b/.changes/unreleased/Fixes-20240201-145323.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix null column index issue during `dbt docs generate` for external tables
+time: 2024-02-01T14:53:23.434624-05:00
+custom:
+  Author: mikealfare
+  Issue: "1079"

--- a/dbt/include/bigquery/macros/catalog/catalog.sql
+++ b/dbt/include/bigquery/macros/catalog/catalog.sql
@@ -121,10 +121,12 @@
         end as table_name,
         tables.table_type,
         tables.table_comment,
-        columns.column_name,
-        columns.column_index,
-        columns.column_type,
-        columns.column_comment,
+        -- coalesce column metadata fields to ensure they are non-null for catalog generation
+        -- external table columns are not present in COLUMN_FIELD_PATHS
+        coalesce(columns.column_name, '<unknown>') as column_name,
+        coalesce(columns.column_index, 1) as column_index,
+        coalesce(columns.column_type, '<unknown>') as column_type,
+        coalesce(columns.column_comment, '') as column_comment,
 
         'Shard count' as `stats__date_shards__label`,
         table_stats.shard_count as `stats__date_shards__value`,


### PR DESCRIPTION
resolves #1252

Forward-port the fix from #1085 to `main`. After merging, we will backport to 1.8.latest (for inclusion in next dbt-bigquery v1.8.x path).