### PR TITLE
Fix/1116 mixed cluster order for mv

### DIFF
--- a/.changes/unreleased/Fixes-20240613-162504.yaml
+++ b/.changes/unreleased/Fixes-20240613-162504.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix mixed cluster order for materialized views
+time: 2024-06-13T16:25:04.020387+02:00
+custom:
+    Author: thmswt
+    Issue: "1116"

--- a/dbt/adapters/bigquery/relation_configs/_cluster.py
+++ b/dbt/adapters/bigquery/relation_configs/_cluster.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, Dict, FrozenSet, Optional
+from typing import Any, Dict, Optional, Tuple
 
 from dbt.adapters.relation_configs import RelationConfigChange
 from dbt.adapters.contracts.relation import RelationConfig
@@ -20,7 +20,7 @@ class BigQueryClusterConfig(BigQueryBaseRelationConfig):
         - Note: can contain up to four columns
     """
 
-    fields: FrozenSet[str]
+    fields: Tuple[str, ...]
 
     @classmethod
     def from_dict(cls, config_dict: Dict[str, Any]) -> Self:
@@ -35,13 +35,13 @@ class BigQueryClusterConfig(BigQueryBaseRelationConfig):
             # users may input a single field as a string
             if isinstance(cluster_by, str):
                 cluster_by = [cluster_by]
-            config_dict.update({"fields": frozenset(cluster_by)})
+            config_dict.update({"fields": tuple(cluster_by)})
 
         return config_dict
 
     @classmethod
     def parse_bq_table(cls, table: BigQueryTable) -> Dict[str, Any]:  # type: ignore
-        config_dict = {"fields": frozenset(table.clustering_fields)}
+        config_dict = {"fields": tuple(table.clustering_fields)}
         return config_dict
 
 

--- a/tests/functional/adapter/materialized_view_tests/test_materialized_view_changes.py
+++ b/tests/functional/adapter/materialized_view_tests/test_materialized_view_changes.py
@@ -22,7 +22,7 @@ class BigQueryMaterializedViewChanges(BigQueryMaterializedViewMixin, Materialize
         assert results.partition.field == "record_valid_date"
         assert results.partition.data_type == "datetime"
         assert results.partition.granularity == "day"
-        assert results.cluster.fields == frozenset({"id", "value"})
+        assert results.cluster.fields == tuple(["id", "value"])
 
     @staticmethod
     def change_config_via_alter(project, materialized_view):
@@ -74,7 +74,7 @@ class BigQueryMaterializedViewChanges(BigQueryMaterializedViewMixin, Materialize
         assert results.partition.field == "value"
         assert results.partition.data_type == "int64"
         assert results.partition.range == {"start": 0, "end": 500, "interval": 50}
-        assert results.cluster.fields == frozenset({"id"})
+        assert results.cluster.fields == tuple(["id"])
 
 
 class TestBigQueryMaterializedViewChangesApply(

--- a/tests/functional/adapter/materialized_view_tests/test_materialized_view_cluster_changes.py
+++ b/tests/functional/adapter/materialized_view_tests/test_materialized_view_cluster_changes.py
@@ -21,7 +21,7 @@ class BigQueryMaterializedViewClusterChanges(
         assert isinstance(results, BigQueryMaterializedViewConfig)
         assert results.options.enable_refresh is True
         assert results.options.refresh_interval_minutes == 60
-        assert results.cluster.fields == frozenset({"id", "value"})
+        assert results.cluster.fields == tuple(["id", "value"])
 
     @staticmethod
     def change_config_via_alter(project, materialized_view):
@@ -48,7 +48,7 @@ class BigQueryMaterializedViewClusterChanges(
         with get_connection(project.adapter):
             results = project.adapter.describe_relation(materialized_view)
         assert isinstance(results, BigQueryMaterializedViewConfig)
-        assert results.cluster.fields == frozenset({"id"})
+        assert results.cluster.fields == tuple(["id"])
 
 
 class TestBigQueryMaterializedViewClusterChangesApply(


### PR DESCRIPTION
resolves dbt-labs/dbt-adapters#586 
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) N/A

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem
On creation of a materialized view the configured `cluster_by` order is not preserved.

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution
Changing the type from `FrozenSet` to `Tuple`.

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
