### PR TITLE
Retry dataproc transient errors

### DIFF
--- a/.changes/unreleased/Fixes-20240708-174437.yaml
+++ b/.changes/unreleased/Fixes-20240708-174437.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Retry Dataproc serverless transient errors
+time: 2024-07-08T17:44:37.756623827Z
+custom:
+    Author: OSalama
+    Issue: "1271"

--- a/dbt/adapters/bigquery/dataproc/batch.py
+++ b/dbt/adapters/bigquery/dataproc/batch.py
@@ -35,7 +35,7 @@ def poll_batch_job(
     response = None
     run_time = 0
     while state in _BATCH_RUNNING_STATES and run_time < timeout:
-        time.sleep(1)
+        time.sleep(1) if state == Batch.State.RUNNING else time.sleep(10)
         response = job_client.get_batch(  # type: ignore
             request=GetBatchRequest(name=batch_name),  # type: ignore
             retry=Retry()

--- a/dbt/adapters/bigquery/dataproc/batch.py
+++ b/dbt/adapters/bigquery/dataproc/batch.py
@@ -9,6 +9,7 @@ from google.cloud.dataproc_v1 import (
     GetBatchRequest,
 )
 from google.protobuf.json_format import ParseDict
+from google.api_core.retry import Retry
 
 from dbt.adapters.bigquery.connections import DataprocBatchConfig
 
@@ -37,6 +38,7 @@ def poll_batch_job(
         time.sleep(1)
         response = job_client.get_batch(  # type: ignore
             request=GetBatchRequest(name=batch_name),  # type: ignore
+            retry=Retry()
         )
         run_time = datetime.now().timestamp() - response.create_time.timestamp()  # type: ignore
         state = response.state


### PR DESCRIPTION
resolves #1271 
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/# N/A

### Problem

Python models that are configured to use dataproc serverless jobs will fail when the polling API call returns a transient 5xx error. The actual dataproc batch job will still run to completion successfully, and data becomes available in the table, but all downstream models will get skipped because dbt thinks it failed.

### Solution

This PR solves the problem by adding exponential retry to the API polling calls, which will retry all transient API errors.

It also increases the time between polling calls while the dataproc job is still in a "pending" state. This is because Dataproc serverless batch jobs take at least 60 seconds to start up, which leads to a lot of additional polling, and increases the chance of getting a transient error.
This increase in time does mean that any models that normally complete within 10 seconds of the Dataproc job transitioning from "pending" to "running" will see increased runtime. In practice I would be very surprised if this were to cause any issues, as this is only impacting jobs that are submitted via dataproc serverless, which are expected to run longer than interactive/dedicated cluster methods.


I have run this in our production environment for 2 weeks with no further issues.
I generated a patch file by checking out `9efeb859d1ac21cab1bb6441acc06ec1328e4888` (release 1.8.1), modifying batch.py with my changes, then `git diff batch.py > batch.py.patch`
I then use the below Dockerfile to apply the patch on top of Python 3.9.8 & dbt-bigquery 1.8.1.

```
FROM python:3.9.8-slim-buster
RUN apt-get update -q && apt-get install -q -y patch
RUN pip install dbt-bigquery==1.8.1
COPY docker/batch.py.patch /tmp/batch.py.patch
RUN patch /usr/local/lib/python3.9/site-packages/dbt/adapters/bigquery/dataproc/batch.py < /tmp/batch.py.patch
```


### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
