### PR TITLE
automate internal release workflow.

### DIFF
--- a/.github/workflows/release-internal.yml
+++ b/.github/workflows/release-internal.yml
@@ -54,6 +54,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Fetch all history for all branches and tags
+
+      - name: Fetch ref
+        run: |
+          git fetch origin ${{ inputs.ref }}:${{ inputs.ref }}
 
       - name: Get last successful Release to Cloud run details and check for new commits
         id: check_new_commits

--- a/.github/workflows/release-internal.yml
+++ b/.github/workflows/release-internal.yml
@@ -8,7 +8,7 @@
 #
 # When?
 #
-# Manual trigger.
+# Manual trigger or cron job every wednesday morning.
 
 name: "Release to Cloud"
 run-name: "Release to Cloud off of ${{ inputs.ref }}"
@@ -32,20 +32,45 @@ on:
         required: true
         default: false
 
+  schedule:
+    - cron: '0 13 * * 3' # Every Wednesday at 8:00 AM central time
+
 defaults:
   run:
     shell: bash
 
 jobs:
+  get-latest-release:
+    runs-on: ubuntu-latest
+    outputs:
+      latest_release: ${{ steps.get_latest_release.outputs.latest_release }}
+    steps:
+      - name: Get latest release
+        id: get_latest_release
+        run: |
+          latest_release=$(curl --silent "https://api.github.com/repos/${{ github.repository }}/releases/latest" | jq -r .tag_name)
+          echo "::set-output name=latest_release::$latest_release"
+
+  check-for-new-commits:
+    runs-on: ubuntu-latest
+    needs: get-latest-release
+    outputs:
+      new_commits: ${{ steps.check_new_commits.outputs.new_commits }}
+    steps:
+      - name: Check for new commits since last release
+        id: check_new_commits
+        run: |
+          last_release_date=$(curl --silent "https://api.github.com/repos/${{ github.repository }}/releases/tags/${{ needs.get-latest-release.outputs.latest_release }}" | jq -r .published_at)
+          new_commits=$(git rev-list --count --since="$last_release_date" ${{ inputs.ref }})
+          echo "::set-output name=new_commits::$new_commits"
+
   invoke-reusable-workflow:
+    if: needs.check-for-new-commits.output.new_commits != '0'
     name: "Build and Release Internally"
-
     uses: "dbt-labs/dbt-release/.github/workflows/internal-archive-release.yml@main"
-
     with:
       package_test_command: "${{ inputs.package_test_command }}"
       dbms_name: "bigquery"
       ref: "${{ inputs.ref }}"
       skip_tests: "${{ inputs.skip_tests }}"
-
     secrets: "inherit"

--- a/.github/workflows/release-internal.yml
+++ b/.github/workflows/release-internal.yml
@@ -40,27 +40,28 @@ defaults:
     shell: bash
 
 jobs:
-  get-latest-release:
+  get-last-successful-run:
     runs-on: ubuntu-latest
     outputs:
-      latest_release: ${{ steps.get_latest_release.outputs.latest_release }}
+      commit_sha: ${{ steps.get_last_successful_run.outputs.commit_sha }}
     steps:
-      - name: Get latest release
-        id: get_latest_release
+      - name: Get last successful run details
+        id: get_last_successful_run
         run: |
-          latest_release=$(curl --silent "https://api.github.com/repos/${{ github.repository }}/releases/latest" | jq -r .tag_name)
-          echo "::set-output name=latest_release::$latest_release"
+          last_run_url=$(curl --silent -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/actions/runs?event=workflow_dispatch&status=success&branch=${{ github.ref }}" | jq -r '.workflow_runs[0].url')
+          commit_sha=$(curl --silent -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" $last_run_url | jq -r '.head_sha')
+          echo "::set-output name=commit_sha::$commit_sha"
 
   check-for-new-commits:
     runs-on: ubuntu-latest
-    needs: get-latest-release
+    needs: get-last-successful-run
     outputs:
       new_commits: ${{ steps.check_new_commits.outputs.new_commits }}
     steps:
       - name: Check for new commits since last release
         id: check_new_commits
         run: |
-          last_release_date=$(curl --silent "https://api.github.com/repos/${{ github.repository }}/releases/tags/${{ needs.get-latest-release.outputs.latest_release }}" | jq -r .published_at)
+          last_release_date=$(curl --silent "https://api.github.com/repos/${{ github.repository }}/releases/tags/${{ needs.get-last-successful-run.outputs.commit_sha }}" | jq -r .published_at)
           new_commits=$(git rev-list --count --since="$last_release_date" ${{ inputs.ref }})
           echo "::set-output name=new_commits::$new_commits"
 

--- a/.github/workflows/release-internal.yml
+++ b/.github/workflows/release-internal.yml
@@ -32,6 +32,11 @@ on:
         type: boolean
         required: true
         default: false
+      dry_run:
+        description: "Is this a dry run? (default to false)"
+        type: boolean
+        required: true
+        default: false
 
   schedule:
     - cron: '0 13 * * 3' # Every Wednesday at 8:00 AM central time
@@ -41,14 +46,19 @@ defaults:
     shell: bash
 
 jobs:
-  get-last-successful-release-run:
+  check-for-new-commits:
     runs-on: ubuntu-latest
     outputs:
-      commit_sha: ${{ steps.get_last_successful_release_run.outputs.commit_sha }}
+      latest_commit_sha: ${{ steps.check_new_commits.outputs.latest_commit_sha }}
+      has_new_commits: ${{ steps.check_new_commits.outputs.has_new_commits }}
     steps:
-      - name: Get last successful Release to Cloud run details
-        id: get_last_successful_release_run
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Get last successful Release to Cloud run details and check for new commits
+        id: check_new_commits
         run: |
+          # Get last successful Release to Cloud run details
           last_run_url=$(curl --silent -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/actions/runs?event=workflow_dispatch&status=success&branch=main&workflow_file=release-internal.yml" | jq -r '.workflow_runs[0].url')
           if [ -z "$last_run_url" ]; then
             echo "No successful Release to Cloud run found."
@@ -61,35 +71,26 @@ jobs:
             exit 1
           fi
           echo "Commit SHA: $commit_sha"
-          echo "commit_sha=$commit_sha" >> "$GITHUB_OUTPUT"
 
-  check-for-new-commits:
-    runs-on: ubuntu-latest
-    needs: get-last-successful-release-run
-    outputs:
-      latest_commit_sha: ${{ steps.check_new_commits.outputs.latest_commit_sha }}
-      has_new_commits: ${{ steps.check_new_commits.outputs.has_new_commits }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Check for new commits since last Release to Cloud run
-        id: check_new_commits
-        run: |
-          last_released_commit_sha=${{ needs.get-last-successful-release-run.outputs.commit_sha }}
-          echo "Last released commit SHA: $last_released_commit_sha"
+          # Check for new commits
+          echo "Last released commit SHA: $commit_sha"
           latest_commit_sha=$(git rev-parse ${{ inputs.ref }})
           echo "Latest commit SHA: $latest_commit_sha"
-          if [ "$last_released_commit_sha" != "$latest_commit_sha" ]; then
+          if [ "$commit_sha" != "$latest_commit_sha" ]; then
             echo "has_new_commits=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_new_commits=false" >> "$GITHUB_OUTPUT"
           fi
           echo "latest_commit_sha=$latest_commit_sha" >> "$GITHUB_OUTPUT"
 
+          # Print the commit SHAs for dry run
+          if [ "${{ inputs.dry_run }}" == "true" ]; then
+            echo "::notice title=Dry Run::Last released commit SHA: $commit_sha, Latest commit SHA: $latest_commit_sha"
+          fi
+
   invoke-reusable-workflow:
     needs: check-for-new-commits
-    if: needs.check-for-new-commits.outputs.has_new_commits == 'true'
+    if: needs.check-for-new-commits.outputs.has_new_commits == 'true' && inputs.dry_run == 'false'
     name: "Build and Release Internally"
     uses: "dbt-labs/dbt-release/.github/workflows/internal-archive-release.yml@main"
     with:

--- a/.github/workflows/release-internal.yml
+++ b/.github/workflows/release-internal.yml
@@ -40,21 +40,21 @@ defaults:
     shell: bash
 
 jobs:
-  get-last-successful-run:
+  get-last-successful-release-run:
     runs-on: ubuntu-latest
     outputs:
-      commit_sha: ${{ steps.get_last_successful_run.outputs.commit_sha }}
+      commit_sha: ${{ steps.get_last_successful_release_run.outputs.commit_sha }}
     steps:
-      - name: Get last successful run details
-        id: get_last_successful_run
+      - name: Get last successful Release to Cloud run details
+        id: get_last_successful_release_run
         run: |
-          last_run_url=$(curl --silent -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/actions/runs?event=workflow_dispatch&status=success&branch=${{ github.ref }}" | jq -r '.workflow_runs[0].url')
+          last_run_url=$(curl --silent -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/actions/runs?event=workflow_dispatch&status=success&branch=${{ github.ref }}&workflow_file=release.internal.yml" | jq -r '.workflow_runs[0].url')
           commit_sha=$(curl --silent -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" $last_run_url | jq -r '.head_sha')
           echo "::set-output name=commit_sha::$commit_sha"
 
   check-for-new-commits:
     runs-on: ubuntu-latest
-    needs: get-last-successful-run
+    needs: get-last-successful-release-run
     outputs:
       new_commits: ${{ steps.check_new_commits.outputs.new_commits }}
     steps:

--- a/.github/workflows/release-internal.yml
+++ b/.github/workflows/release-internal.yml
@@ -9,6 +9,7 @@
 # When?
 #
 # Manual trigger or cron job every wednesday morning.
+# action will check if a new commit was added if not should do nothing
 
 name: "Release to Cloud"
 run-name: "Release to Cloud off of ${{ inputs.ref }}"
@@ -52,7 +53,8 @@ jobs:
           echo "Last run URL: $last_run_url"
           commit_sha=$(curl --silent -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" $last_run_url | jq -r '.head_sha')
           echo "Commit SHA: $commit_sha"
-          echo "::set-output name=commit_sha::$commit_sha"
+          echo "commit_sha=$commit_sha" >> "$GITHUB_OUTPUT"
+
   check-for-new-commits:
     runs-on: ubuntu-latest
     needs: get-last-successful-release-run
@@ -60,21 +62,25 @@ jobs:
       latest_commit_sha: ${{ steps.check_new_commits.outputs.latest_commit_sha }}
       has_new_commits: ${{ steps.check_new_commits.outputs.has_new_commits }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
       - name: Check for new commits since last Release to Cloud run
         id: check_new_commits
         run: |
-          last_commit_sha=${{ needs.get-last-successful-release-run.outputs.commit_sha }}
-          echo "Last successful commit SHA: $last_commit_sha"
+          last_released_commit_sha=${{ needs.get-last-successful-release-run.outputs.commit_sha }}
+          echo "Last released commit SHA: $last_released_commit_sha"
           latest_commit_sha=$(git rev-parse ${{ inputs.ref }})
           echo "Latest commit SHA: $latest_commit_sha"
-          if [ "$last_commit_sha" != "$latest_commit_sha" ]; then
-            echo "::set-output name=has_new_commits::true"
+          if [ "$last_released_commit_sha" != "$latest_commit_sha" ]; then
+            echo "has_new_commits=true" >> "$GITHUB_OUTPUT"
           else
-            echo "::set-output name=has_new_commits::false"
+            echo "has_new_commits=false" >> "$GITHUB_OUTPUT"
           fi
-          echo "::set-output name=latest_commit_sha::$latest_commit_sha"
+          echo "latest_commit_sha=$latest_commit_sha" >> "$GITHUB_OUTPUT"
 
   invoke-reusable-workflow:
+    needs: check-for-new-commits
     if: needs.check-for-new-commits.outputs.has_new_commits == 'true'
     name: "Build and Release Internally"
     uses: "dbt-labs/dbt-release/.github/workflows/internal-archive-release.yml@main"
@@ -83,4 +89,4 @@ jobs:
       dbms_name: "bigquery"
       ref: "${{ inputs.ref }}"
       skip_tests: "${{ inputs.skip_tests }}"
-    secrets: inherit
+    secrets: "inherit"

--- a/.github/workflows/release-internal.yml
+++ b/.github/workflows/release-internal.yml
@@ -50,8 +50,16 @@ jobs:
         id: get_last_successful_release_run
         run: |
           last_run_url=$(curl --silent -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/actions/runs?event=workflow_dispatch&status=success&branch=main&workflow_file=release-internal.yml" | jq -r '.workflow_runs[0].url')
+          if [ -z "$last_run_url" ]; then
+            echo "No successful Release to Cloud run found."
+            exit 1
+          fi
           echo "Last run URL: $last_run_url"
-          commit_sha=$(curl --silent -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" $last_run_url | jq -r '.head_sha')
+          commit_sha=$(curl --silent -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" "$last_run_url" | jq -r '.head_sha')
+          if [ -z "$commit_sha" ]; then
+            echo "No commit SHA found for the last successful run."
+            exit 1
+          fi
           echo "Commit SHA: $commit_sha"
           echo "commit_sha=$commit_sha" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/release-internal.yml
+++ b/.github/workflows/release-internal.yml
@@ -49,24 +49,34 @@ jobs:
         id: get_last_successful_release_run
         run: |
           last_run_url=$(curl --silent -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/actions/runs?event=workflow_dispatch&status=success&branch=${{ github.ref }}&workflow_file=release.internal.yml" | jq -r '.workflow_runs[0].url')
+          echo "Last run URL: $last_run_url"
           commit_sha=$(curl --silent -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" $last_run_url | jq -r '.head_sha')
+          echo "Commit SHA: $commit_sha"
           echo "::set-output name=commit_sha::$commit_sha"
 
   check-for-new-commits:
     runs-on: ubuntu-latest
     needs: get-last-successful-release-run
     outputs:
-      new_commits: ${{ steps.check_new_commits.outputs.new_commits }}
+      latest_commit_sha: ${{ steps.check_new_commits.outputs.latest_commit_sha }}
+      has_new_commits: ${{ steps.check_new_commits.outputs.has_new_commits }}
     steps:
-      - name: Check for new commits since last release
+      - name: Check for new commits since last Release to Cloud run
         id: check_new_commits
         run: |
-          last_release_date=$(curl --silent "https://api.github.com/repos/${{ github.repository }}/releases/tags/${{ needs.get-last-successful-run.outputs.commit_sha }}" | jq -r .published_at)
-          new_commits=$(git rev-list --count --since="$last_release_date" ${{ inputs.ref }})
-          echo "::set-output name=new_commits::$new_commits"
+          last_commit_sha=${{ needs.get-last-successful-release-run.outputs.commit_sha }}
+          echo "Last successful commit SHA: $last_commit_sha"
+          latest_commit_sha=$(git rev-parse ${{ inputs.ref }})
+          echo "Latest commit SHA: $latest_commit_sha"
+          if [ "$last_commit_sha" != "$latest_commit_sha" ]; then
+            echo "::set-output name=has_new_commits::true"
+          else
+            echo "::set-output name=has_new_commits::false"
+          fi
+          echo "::set-output name=latest_commit_sha::$latest_commit_sha"
 
   invoke-reusable-workflow:
-    if: needs.check-for-new-commits.output.new_commits != '0'
+    if: needs.check-for-new-commits.outputs.has_new_commits == 'true'
     name: "Build and Release Internally"
     uses: "dbt-labs/dbt-release/.github/workflows/internal-archive-release.yml@main"
     with:
@@ -74,4 +84,4 @@ jobs:
       dbms_name: "bigquery"
       ref: "${{ inputs.ref }}"
       skip_tests: "${{ inputs.skip_tests }}"
-    secrets: "inherit"
+    secrets: inherit

--- a/.github/workflows/release-internal.yml
+++ b/.github/workflows/release-internal.yml
@@ -48,12 +48,11 @@ jobs:
       - name: Get last successful Release to Cloud run details
         id: get_last_successful_release_run
         run: |
-          last_run_url=$(curl --silent -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/actions/runs?event=workflow_dispatch&status=success&branch=${{ github.ref }}&workflow_file=release.internal.yml" | jq -r '.workflow_runs[0].url')
+          last_run_url=$(curl --silent -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/actions/runs?event=workflow_dispatch&status=success&branch=main&workflow_file=release-internal.yml" | jq -r '.workflow_runs[0].url')
           echo "Last run URL: $last_run_url"
           commit_sha=$(curl --silent -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" $last_run_url | jq -r '.head_sha')
           echo "Commit SHA: $commit_sha"
           echo "::set-output name=commit_sha::$commit_sha"
-
   check-for-new-commits:
     runs-on: ubuntu-latest
     needs: get-last-successful-release-run


### PR DESCRIPTION

 https://github.com/dbt-labs/adapters-team-private/issues/168
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem
manually having to kick off the internal release workflow is a time eater, we can try to automate it as much as possible and just check it in the start of day.
<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution
add a cron job call for early mornings on a specified day a week (currently weds) and have the workflow first compare commit to last release if there is a new commit continue with release else don't.
<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
