### PR TITLE
Pin `setuptools` to address setuptools#4483

### DIFF
--- a/.changes/unreleased/Fixes-20240718-093755.yaml
+++ b/.changes/unreleased/Fixes-20240718-093755.yaml
@@ -1,5 +1,5 @@
 kind: Fixes
-body: Pin `setuptools` to address pypa/setuptools#4483ls
+body: Pin `setuptools` to address pypa/setuptools#4483
 time: 2024-07-18T09:37:55.774924-04:00
 custom:
   Author: mikealfare

--- a/.changes/unreleased/Fixes-20240718-093755.yaml
+++ b/.changes/unreleased/Fixes-20240718-093755.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Pin `setuptools` to address pypa/setuptools#4483ls
+time: 2024-07-18T09:37:55.774924-04:00
+custom:
+  Author: mikealfare
+  Issue: "1284"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -184,8 +184,8 @@ jobs:
       - name: Install python dependencies
         run: |
           python -m pip install --user --upgrade pip
-          python -m pip install --upgrade wheel setuptools twine check-wheel-contents
-          python -m pip --version
+          python -m pip install -r build-requirements.txt
+
       - uses: actions/download-artifact@v3
         with:
           name: dist

--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -1,0 +1,5 @@
+bumpversion~=0.6.0
+check-wheel-contents~=0.6.0
+setuptools~=70.0
+twine~=5.0
+wheel~=0.42

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,7 +7,6 @@ git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-tests-adapter
 # if version 1.x or greater -> pin to major version
 # if version 0.x -> pin to minor
 black>=24.3
-bumpversion~=0.6.0
 click~=8.1
 ddtrace==2.3.0
 flake8~=7.0
@@ -29,5 +28,5 @@ tox~=4.11
 types-pytz~=2023.3
 types-protobuf~=4.24
 types-requests~=2.31
-twine~=4.0
-wheel~=0.42
+
+-r build-requirements.txt


### PR DESCRIPTION
### Problem

`setuptools` released `71.0.0` and `71.0.1` last night which contains a breaking change. This is blocking our CI. See https://github.com/pypa/setuptools/issues/4483 for more information.

### Solution

- create a separate `build-requirements.txt` file to isolate build dependencies
- pin `setuptools~=70.0` in this file
- reference this file in `dev-requirements.txt` for backwards compatibility
- install from this file in workflows instead of running `pip install --upgrade setuptools ...`

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX