### PR TITLE
adding  config option for table and incremental materializaions

### DIFF
--- a/dbt/include/bigquery/macros/materializations/incremental.sql
+++ b/dbt/include/bigquery/macros/materializations/incremental.sql
@@ -86,6 +86,8 @@
 
   {{ run_hooks(pre_hooks) }}
 
+  {{ bigquery__run_script_headers(config.get('script_headers')) }}
+
   {% if partition_by.copy_partitions is true and strategy != 'insert_overwrite' %} {#-- We can't copy partitions with merge strategy --#}
         {% set wrong_strategy_msg -%}
         The 'copy_partitions' option requires the 'incremental_strategy' option to be set to 'insert_overwrite'.

--- a/dbt/include/bigquery/macros/materializations/table.sql
+++ b/dbt/include/bigquery/macros/materializations/table.sql
@@ -11,6 +11,8 @@
 
   {{ run_hooks(pre_hooks) }}
 
+  {{ bigquery__run_script_headers(config.get('script_headers')) }}
+
   {#
       We only need to drop this thing if it is not a table.
       If it _is_ already a table, then we can overwrite it without downtime

--- a/dbt/include/bigquery/macros/utils/run_script_headers.sql
+++ b/dbt/include/bigquery/macros/utils/run_script_headers.sql
@@ -1,0 +1,21 @@
+{% macro bigquery__run_script_headers(script_headers) %}
+    {%- if script_headers is not none -%}
+        {%- if script_headers is string -%}
+            {%- set script_headers = [script_headers] -%}
+        {%- endif -%}
+
+        {%- set formatted_script_headers = [] -%}
+        
+        {%- for script_header in script_headers -%}
+            {%- set trimmed_script_header = script_header.strip() -%}
+            {%- if not trimmed_script_header.endswith(';') -%}
+                {%- set formatted_script_header = trimmed_script_header ~ ';' -%}
+            {%- else -%}
+                {%- set formatted_script_header = trimmed_script_header -%}
+            {%- endif -%}
+            {%- do formatted_script_headers.append(formatted_script_header) -%}
+        {%- endfor -%}
+
+        {{ formatted_script_headers | join('\n') }}
+    {%- endif -%}
+{%- endmacro -%}


### PR DESCRIPTION
resolves #
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->



BigQuery generates inefficient execution plans when doing comparisons on nested queries. For example;

```SQL
{{
  config(
    materialized='table'
  )
}}

SELECT id
FROM `shopify-stg-dw`.`greg_sandbox`.`another_table`
WHERE created_at < (SELECT MAX(created_at) FROM `shopify-stg-dw`.`greg_sandbox`.`my_table`)
```

BigQuery also generates inefficient execution plans using a CTE approach. For example;

```SQL
{{
  config(
    materialized='table'
  )
}}

WITH max_created_at AS (
  SELECT MAX(created_at) AS max_date
  FROM `shopify-stg-dw`.`greg_sandbox`.`my_table`
)
SELECT id
FROM `shopify-stg-dw`.`greg_sandbox`.`another_table`
WHERE created_at < (SELECT max_date FROM max_created_at)
```

BigQuery variables are unable to be used as they require declaration at the top of a script. The existing `pre_hook` options are not suitable as they run in a separate script.

So the current best practices to solve this in dbt is to use a `run_query` macro to set a dbt variable from a SQL query. This results in two separate SQL scripts being generated. For example;


```SQL
{{
  config(
    materialized='table'
  )
}}

{%- set latest_my_table_data = run_query("SELECT MAX(created_at) FROM `shopify-stg-dw`.`greg_sandbox`.`my_table`")[0][0] -%}

SELECT id
FROM `shopify-stg-dw`.`greg_sandbox`.`another_table`
WHERE created_at < TIMESTAMP("{{ latest_my_table_data }}")
```

This approach executes these two separate scripts;

```SQL
/* {"app": "dbt", "dbt_version": "1.7.13", "profile_name": "data_warehouse", "target_name": "dev", "node_id": "model.data_warehouse.bq_variables_example"} */

SELECT MAX(created_at) FROM `shopify-stg-dw`.`greg_sandbox`.`my_table`
```

```SQL
/* {"app": "dbt", "dbt_version": "1.7.13", "profile_name": "data_warehouse", "target_name": "dev", "node_id": "model.data_warehouse.bq_variables_example"} */

CREATE OR REPLACE TABLE `shopify-stg-dw`.`greg_sandbox`.`bq_variables_example` OPTIONS( 
  expiration_timestamp=TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 168 hour)
) AS (
  SELECT id
  FROM `shopify-stg-dw`.`greg_sandbox`.`another_table`
  WHERE created_at < TIMESTAMP("2024-07-31 18:45:08.176533 UTC")
);
```

The current solution has a few drawbacks;
 - It requires an additional separate SQL script to be run for each defined variable.
 - There are limitations on the size of the dbt variable because of BigQuery's script limits.
 - The type of variable is not necessarily maintained, for instance in the example above the query output is a `TIMESTAMP` which is converted to a string in the dbt variable and then `CAST` back to a `TIMESTAMP` in the subsequent query.
 - All of these issues are exabated when a model requires multiple such variables.

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

This macro and materialization update enables running SQL code at the beginning of a BigQuery SQL script. Which allows dbt models to `DECLARE` and `SET` BigQuery variables before the `CREATE OR REPLACE TABLE` statement.

```SQL
{{
  config(
    materialized='table',
    script_headers=[
      "DECLARE latest_my_table_data TIMESTAMP;"
      "SET latest_my_table_data = (SELECT MAX(created_at) FROM `data-warehouse`.`greg_sandbox`.`my_table`);"
    ]
  )
}}

SELECT id
FROM `shopify-stg-dw`.`greg_sandbox`.`another_table`
WHERE created_at < latest_my_table_data
```

Using this approach, what would have required two separate scripts to produce an efficient execution plan in BigQuery can now be achieved in a single script.

```SQL
/* {"app": "dbt", "dbt_version": "1.7.13", "profile_name": "data_warehouse", "target_name": "dev", "node_id": "model.data_warehouse.bq_variables_example"} */

DECLARE latest_my_table_data TIMESTAMP;
SET latest_my_table_data = (SELECT MAX(created_at) FROM `data-warehouse`.`greg_sandbox`.`my_table`);

CREATE OR REPLACE TABLE `data-warehouse`.`sandbox`.`bq_variables_example`
OPTIONS(
  expiration_timestamp=TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 168 hour)
) AS (
  SELECT id
  FROM `shopify-stg-dw`.`greg_sandbox`.`another_table`
  WHERE created_at < latest_my_table_data
);
```

#### Alternative approaches considered;

Having a `bq_varables` option that accepted a list of dicts with information about the variable type and defaults. I decided against this as there may be other use cases for running SQL within a single script at the beginning of a model.

Not making these changes and only using dbt variables instead of BigQuery variables. I decided against this as setting dbt variables from a SQL query currently requires executing the `run_query()` macro which generates a separate SQL script. As mentioned above, this can result in a single model creating dozens of separate SQL scripts to run.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
