### PR TITLE
Make dev-requirements.txt look like other repos and work with update_dev_dependency_branches.sh

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,7 +2,7 @@
 git+https://github.com/dbt-labs/dbt-adapters.git
 git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-tests-adapter
 git+https://github.com/dbt-labs/dbt-common.git
-git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core
+git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
 
 # dev
 ddtrace==2.3.0


### PR DESCRIPTION
### Problem

When updating the integration.yml workflow, updating dbt-core branch didn't work because the format in dev-requirements.txt didn't match what was expected in update_dev_dependency_branches.sh

### Solution

Add the "#egg" snippet that the other repos have and that update_dev_dependency_branches.sh expects.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
