### PR TITLE
Fix the logs upload step for integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -229,18 +229,18 @@ jobs:
           GCS_BUCKET: dbt-ci
         run: tox -- --ddtrace
 
-      - uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: logs
-          path: ./logs
-          overwrite: true
-
       - name: Get current date
         if: always()
         id: date
         run: |
           echo "date=$(date +'%Y-%m-%dT%H_%M_%S')" >> $GITHUB_OUTPUT #no colons allowed for artifacts
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: logs_${{ matrix.python-version }}_${{ matrix.os }}_${{ matrix.adapter }}-${{ steps.date.outputs.date }}
+          path: ./logs
+          overwrite: true
 
       - uses: actions/upload-artifact@v4
         if: always()


### PR DESCRIPTION
### Problem

The new version of `upload-artifacts` requires a unique artifact name for upload whereas the old one allowed for overwriting the existing artifact. This was addressed for the test results, but not the logs resulting from running the tests.

### Solution

Add the same uniqueness namespace to the logs artifact that is used for the test results artifact.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
