### PR TITLE
Adding column schema attributes

### DIFF
--- a/dbt/adapters/bigquery/column.py
+++ b/dbt/adapters/bigquery/column.py
@@ -19,6 +19,8 @@ class BigQueryColumn(Column):
     }
     fields: List[Self]  # type: ignore
     mode: str
+    description: str
+    default_value_expression: str
 
     def __init__(
         self,
@@ -26,6 +28,8 @@ class BigQueryColumn(Column):
         dtype: str,
         fields: Optional[Iterable[SchemaField]] = None,
         mode: str = "NULLABLE",
+        description: Optional[Union[SchemaField]] = "", 
+        default_value_expression: Optional[Union[SchemaField]] = "",
     ) -> None:
         super().__init__(column, dtype)
 
@@ -34,6 +38,8 @@ class BigQueryColumn(Column):
 
         self.fields = self.wrap_subfields(fields)
         self.mode = mode
+        self.description = description
+        self.default_value_expression = default_value_expression
 
     @classmethod
     def wrap_subfields(cls: Type[Self], fields: Iterable[SchemaField]) -> List[Self]:
@@ -115,7 +121,7 @@ class BigQueryColumn(Column):
         return self.is_string() and other_column.is_string()
 
     def __repr__(self) -> str:
-        return "<BigQueryColumn {} ({}, {})>".format(self.name, self.data_type, self.mode)
+        return "<BigQueryColumn {} ({}, {}, {}, {})>".format(self.name, self.data_type, self.mode, self.description, self.default_value_expression)
 
     def column_to_bq_schema(self) -> SchemaField:
         """Convert a column to a bigquery schema object."""

--- a/dbt/adapters/bigquery/impl.py
+++ b/dbt/adapters/bigquery/impl.py
@@ -401,7 +401,7 @@ class BigQueryAdapter(BaseAdapter):
         for col in table.schema:
             # BigQuery returns type labels that are not valid type specifiers
             dtype = self.Column.translate_type(col.field_type)
-            column = self.Column(col.name, dtype, col.fields, col.mode)
+            column = self.Column(col.name, dtype, col.fields, col.mode, col.description, col.default_value_expression)
             columns.append(column)
 
         return columns


### PR DESCRIPTION
resolves # https://github.com/dbt-labs/dbt-bigquery/issues/1265
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#NA

### Problem

Before this PR is merged, we could not identify if the target table have different description and default_value_expression than the model transformation. If the model use the Bigquery API copy_table, and we don't have description and default_value_expression defined in the schema.yml, the metadata will be deleted. 

By extending this function **_get_dbt_columns_from_bq_table** to extract and store the description and default_value_expression from BigQuery's SchemaField objects, we could seamlessly compare the model transformation data with the table destination and decide if replace it or not with the information in the project yaml file.



### Solution

One option to avoid deleting the metadata in the target table is using the feature persist_docs = true, but this means an extra step in the process, have to fill all the column descriptions in yml files, and is needed a table.update permission.

With this PR, we avoid this extra step and the metadata is updated with the transformation itself, with the API copy_table or MERGE statement, faster and cheaper.

