### PR TITLE
Catch google `NotFound` exception as a `DbtDatabaseError`

### DIFF
--- a/.changes/unreleased/Fixes-20241001-193207.yaml
+++ b/.changes/unreleased/Fixes-20241001-193207.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Catch additional database error exception, NotFound, as a DbtDatabaseError instead
+  of defaulting to a DbtRuntimeError
+time: 2024-10-01T19:32:07.304353-04:00
+custom:
+  Author: mikealfare
+  Issue: "1360"

--- a/dbt/adapters/bigquery/connections.py
+++ b/dbt/adapters/bigquery/connections.py
@@ -268,6 +268,10 @@ class BigQueryConnectionManager(BaseConnectionManager):
             message = "Access denied while running query"
             self.handle_error(e, message)
 
+        except google.cloud.exceptions.NotFound as e:
+            message = "Not found while running query"
+            self.handle_error(e, message)
+
         except google.auth.exceptions.RefreshError as e:
             message = (
                 "Unable to generate access token, if you're using "


### PR DESCRIPTION
### Problem

We were not catching a database exception and then returning the result as a runtime exception. This was caught in a test that was recently updated to expect a database exception. The functionality that changed used to not run this code at all, hence it used to pass.

### Solution

Add another condition for catching database exceptions.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
