### PR TITLE
Fix dynamic models with contract enabled

### DIFF
--- a/dbt/include/bigquery/macros/adapters/columns.sql
+++ b/dbt/include/bigquery/macros/adapters/columns.sql
@@ -8,7 +8,7 @@
         {%- set partition_by = adapter.parse_partition_by(raw_partition_by) -%}
 
         declare _dbt_max_partition {{ partition_by.data_type_for_partition() }} default (
-        select max({{ partition_by.field }}) from {{ relation }}
+        select max({{ partition_by.field }}) from {{ this }}
         where {{ partition_by.field }} is not null );
     {%- endif -%}
     select * from (

--- a/dbt/include/bigquery/macros/adapters/columns.sql
+++ b/dbt/include/bigquery/macros/adapters/columns.sql
@@ -4,10 +4,12 @@
     {%- endif -%}
     {%- set contract_config = config.get('contract') -%}
     {%- if contract_config.enforced and '_dbt_max_partition' in compiled_code -%}
+        {%- set raw_partition_by = config.get('partition_by', none) -%}
+        {%- set partition_by = adapter.parse_partition_by(raw_partition_by) -%}
+
         declare _dbt_max_partition {{ partition_by.data_type_for_partition() }} default (
         select max({{ partition_by.field }}) from {{ relation }}
-        where {{ partition_by.field }} is not null
-    );
+        where {{ partition_by.field }} is not null );
     {%- endif -%}
     select * from (
         {{ select_sql }}

--- a/dbt/include/bigquery/macros/adapters/columns.sql
+++ b/dbt/include/bigquery/macros/adapters/columns.sql
@@ -2,6 +2,13 @@
     {%- if select_sql_header is not none -%}
     {{ select_sql_header }}
     {%- endif -%}
+    {%- set contract_config = config.get('contract') -%}
+    {%- if contract_config.enforced and '_dbt_max_partition' in compiled_code -%}
+        declare _dbt_max_partition {{ partition_by.data_type_for_partition() }} default (
+        select max({{ partition_by.field }}) from {{ relation }}
+        where {{ partition_by.field }} is not null
+    );
+    {%- endif -%}
     select * from (
         {{ select_sql }}
     ) as __dbt_sbq


### PR DESCRIPTION
resolves dbt-labs/dbt-adapters#583

### Problem

When a model is Contract Enforced and the sql statement contains the **_dbt_max_partition** variable, dbt does not declare the variable before creating the cte.

This results in the following error:
 -  Unrecognized name: _dbt_max_partition at  ..

### Solution

This PR fixes the bigquery__get_empty_subquery_sql macro, by checking 2 conditions: 
1) if the model is contact enforced 
2) if the model contains _dbt_max_partition variable 

If the conditions are met, the _dbt_max_partition is declared.
