### PR TITLE
FEATURE: Add support for google.auth.credentials.AnonymousCredentials

### DIFF
--- a/.changes/unreleased/Features-20241020-112955.yaml
+++ b/.changes/unreleased/Features-20241020-112955.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Support google.auth.credentials.AnonymousCredentials for bigquery enabling to unit test models in isolation locally.
+time: 2024-10-20T11:29:55.098322635Z
+custom:
+    Author: shrivastava-ankur
+    Issue: "1377"

--- a/dbt/adapters/bigquery/connections.py
+++ b/dbt/adapters/bigquery/connections.py
@@ -6,7 +6,6 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field
 import uuid
 
-from google.api_core.client_options import ClientOptions
 from google.auth.credentials import AnonymousCredentials
 from mashumaro.helper import pass_through
 
@@ -130,6 +129,7 @@ class BigQueryCredentials(Credentials):
     schema: Optional[str] = None
     execution_project: Optional[str] = None
     quota_project: Optional[str] = None
+    api_endpoint: Optional[str] = None
     location: Optional[str] = None
     priority: Optional[Priority] = None
     maximum_bytes_billed: Optional[int] = None
@@ -139,7 +139,6 @@ class BigQueryCredentials(Credentials):
     job_retries: Optional[int] = 1
     job_creation_timeout_seconds: Optional[int] = None
     job_execution_timeout_seconds: Optional[int] = None
-    client_options: Optional[Dict[str, Any]] = None
 
     # Keyfile json creds (unicode or base 64 encoded)
     keyfile: Optional[str] = None
@@ -206,13 +205,13 @@ class BigQueryCredentials(Credentials):
             "schema",
             "location",
             "priority",
+            "api_endpoint",
             "maximum_bytes_billed",
             "impersonate_service_account",
             "job_retry_deadline_seconds",
             "job_retries",
             "job_creation_timeout_seconds",
             "job_execution_timeout_seconds",
-            "client_options",
             "timeout_seconds",
             "client_id",
             "token_uri",
@@ -419,11 +418,12 @@ class BigQueryConnectionManager(BaseConnectionManager):
         execution_project = profile_credentials.execution_project
         quota_project = profile_credentials.quota_project
         location = getattr(profile_credentials, "location", None)
-        client_options_kwargs = getattr(profile_credentials, "client_options", None)
+        api_endpoint = getattr(profile_credentials, "api_endpoint", None)
 
-        options = ClientOptions(**client_options_kwargs) if client_options_kwargs else None
         info = client_info.ClientInfo(user_agent=f"dbt-bigquery-{dbt_version.version}")
-        options = client_options.ClientOptions(quota_project_id=quota_project)
+        options = client_options.ClientOptions(
+            api_endpoint=api_endpoint, quota_project_id=quota_project
+        )
         return google.cloud.bigquery.Client(
             execution_project,
             creds,

--- a/tests/unit/test_bigquery_connection_manager.py
+++ b/tests/unit/test_bigquery_connection_manager.py
@@ -1,6 +1,8 @@
 import json
 import unittest
 from contextlib import contextmanager
+
+from google.auth.credentials import AnonymousCredentials
 from requests.exceptions import ConnectionError
 from unittest.mock import patch, MagicMock, Mock, ANY
 
@@ -8,7 +10,7 @@ import dbt.adapters
 
 from dbt.adapters.bigquery import BigQueryCredentials
 from dbt.adapters.bigquery import BigQueryRelation
-from dbt.adapters.bigquery.connections import BigQueryConnectionManager
+from dbt.adapters.bigquery.connections import BigQueryConnectionManager, BigQueryConnectionMethod
 
 
 class TestBigQueryConnectionManager(unittest.TestCase):
@@ -174,3 +176,17 @@ class TestBigQueryConnectionManager(unittest.TestCase):
             database="project", schema="dataset", identifier="table2"
         )
         self.connections.copy_bq_table(source, destination, write_disposition)
+
+    def test_local_test_container_connection(self):
+        # Create a BigQueryCredentials instance with the anonymous method
+        credentials = BigQueryCredentials(
+            method=BigQueryConnectionMethod.ANONYMOUS,
+            database="test-database",
+            schema="test-schema",
+        )
+
+        # Get the Google credentials using the connection manager
+        google_credentials = BigQueryConnectionManager.get_google_credentials(credentials)
+
+        # Assert that the credentials are an instance of AnonymousCredentials
+        self.assertIsInstance(google_credentials, AnonymousCredentials)


### PR DESCRIPTION
resolves #
[#1377](https://github.com/dbt-labs/dbt-bigquery/issues/1377) 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem
Currently there is no way to run dbt-bigquery locally using big-query emulator.
<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution
Support google.auth.credentials.AnonymousCredentials for bigquery enabling to unit test models in isolation locally.

- introduced new connection method `anonymous` to use of AnonymousCredentials 
- Ability client_options (specifically `api_endpoint` to connect to local instance) to client instantiation
<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
