### PR TITLE
use "direct" write for non-partitioned python model materializations

### DIFF
--- a/.changes/unreleased/Fixes-20241028-172719.yaml
+++ b/.changes/unreleased/Fixes-20241028-172719.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: use "direct" write for non-partitioned python model materializations
+time: 2024-10-28T17:27:19.306348-07:00
+custom:
+  Author: colin-rogers-dbt
+  Issue: "1318"

--- a/dbt/include/bigquery/macros/materializations/table.sql
+++ b/dbt/include/bigquery/macros/materializations/table.sql
@@ -125,6 +125,7 @@ df.write \
   {%- endif %}
   {%- endif %}
   {% else %}
+  # if no partitioning is specified, we can write directly
   .option("writeMethod", "direct") \
   {%- endif %}
   {%- if raw_cluster_by is not none %}

--- a/dbt/include/bigquery/macros/materializations/table.sql
+++ b/dbt/include/bigquery/macros/materializations/table.sql
@@ -125,8 +125,7 @@ df.write \
   {%- endif %}
   {%- endif %}
   {% else %}
-  # if no partitioning is specified, we can write directly
-  .option("writeMethod", "direct") \
+  .option("writeMethod", "direct") \ # if no partitioning is specified, we can write directly
   {%- endif %}
   {%- if raw_cluster_by is not none %}
   .option("clusteredFields", "{{- raw_cluster_by | join(',') -}}") \

--- a/dbt/include/bigquery/macros/materializations/table.sql
+++ b/dbt/include/bigquery/macros/materializations/table.sql
@@ -116,17 +116,20 @@ else:
 df.write \
   .mode("overwrite") \
   .format("bigquery") \
-  .option("writeMethod", "indirect").option("writeDisposition", 'WRITE_TRUNCATE') \
   {%- if partition_config is not none %}
+  .option("writeMethod", "indirect") \
   {%- if partition_config.data_type | lower in ('date','timestamp','datetime') %}
   .option("partitionField", "{{- partition_config.field -}}") \
   {%- if partition_config.granularity is not none %}
   .option("partitionType", "{{- partition_config.granularity| upper -}}") \
   {%- endif %}
   {%- endif %}
+  {% else %}
+  .option("writeMethod", "direct") \
   {%- endif %}
   {%- if raw_cluster_by is not none %}
   .option("clusteredFields", "{{- raw_cluster_by | join(',') -}}") \
   {%- endif %}
+  .option("writeDisposition", 'WRITE_TRUNCATE') \
   .save("{{target_relation}}")
 {% endmacro %}

--- a/dbt/include/bigquery/macros/materializations/table.sql
+++ b/dbt/include/bigquery/macros/materializations/table.sql
@@ -115,7 +115,7 @@ else:
 
 # For writeMethod we need to use "indirect" if materializing a partitioned table
 # otherwise we can use "direct". Note that indirect will fail if the GCS bucket has a retention policy set on it.
-{%- if partition_config is not none %}
+{%- if partition_config %}
       {%- set write_method = 'indirect' -%}
 {%- else %}
       {% set write_method = 'direct' -%}

--- a/dbt/include/bigquery/macros/materializations/table.sql
+++ b/dbt/include/bigquery/macros/materializations/table.sql
@@ -125,7 +125,7 @@ df.write \
   {%- endif %}
   {%- endif %}
   {% else %}
-  .option("writeMethod", "direct") \# if no partitioning is specified, we can write directly
+  .option("writeMethod", "direct") \
   {%- endif %}
   {%- if raw_cluster_by is not none %}
   .option("clusteredFields", "{{- raw_cluster_by | join(',') -}}") \

--- a/dbt/include/bigquery/macros/materializations/table.sql
+++ b/dbt/include/bigquery/macros/materializations/table.sql
@@ -125,7 +125,7 @@ df.write \
   {%- endif %}
   {%- endif %}
   {% else %}
-  .option("writeMethod", "direct") \ # if no partitioning is specified, we can write directly
+  .option("writeMethod", "direct") \# if no partitioning is specified, we can write directly
   {%- endif %}
   {%- if raw_cluster_by is not none %}
   .option("clusteredFields", "{{- raw_cluster_by | join(',') -}}") \

--- a/tests/functional/adapter/test_grant_access_to.py
+++ b/tests/functional/adapter/test_grant_access_to.py
@@ -87,15 +87,6 @@ class TestAccessGrantSucceeds:
 
 
 class TestAccessGrantFails:
-    @pytest.fixture(scope="class", autouse=True)
-    def setup(self, project):
-        with project.adapter.connection_named("__test_grants"):
-            relation = project.adapter.Relation.create(
-                database=project.database, schema=f"{project.test_schema}_seeds"
-            )
-            yield relation
-            project.adapter.drop_relation(relation)
-
     @pytest.fixture(scope="class")
     def models(self):
         return {

--- a/tests/functional/adapter/test_grant_access_to.py
+++ b/tests/functional/adapter/test_grant_access_to.py
@@ -95,6 +95,7 @@ class TestAccessGrantFails:
             )
             yield relation
             project.adapter.drop_relation(relation)
+
     @pytest.fixture(scope="class")
     def models(self):
         return {

--- a/tests/functional/adapter/test_grant_access_to.py
+++ b/tests/functional/adapter/test_grant_access_to.py
@@ -87,6 +87,14 @@ class TestAccessGrantSucceeds:
 
 
 class TestAccessGrantFails:
+    @pytest.fixture(scope="class", autouse=True)
+    def setup(self, project):
+        with project.adapter.connection_named("__test_grants"):
+            relation = project.adapter.Relation.create(
+                database=project.database, schema=f"{project.test_schema}_seeds"
+            )
+            yield relation
+            project.adapter.drop_relation(relation)
     @pytest.fixture(scope="class")
     def models(self):
         return {


### PR DESCRIPTION
resolves #1318

In order to support partitioned materializations in BQ python models we we switched from "direct" to "indirect" mode when writing model results in Dataproc back to BigQuery. As the naming implies "indirect" temporarily stages data in the provided GCS bucket. If a user has a retention policy on the bucket this will fail as the bucket won't allow Dataproc to delete these temp files as it goes. 

This PR sidesteps that issue to ensure backwards compatibility with <1.7 created models by using "direct" write when a partitioned config is not provided.  

Note: I have not added any new testing to cover the case where a user has set a retention policy. Ultimately I think this is an edge case we don't need to test against but we should document that a bucket retention policy cannot be used with a partitioned python model as a follow up

[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
