### PR TITLE
Drop temp table if exists

### DIFF
--- a/.changes/unreleased/Fixes-20241108-154557.yaml
+++ b/.changes/unreleased/Fixes-20241108-154557.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Cleans up the temp table created by the merge incremental stratergy when checking the schema
+time: 2024-11-08T15:45:57.570611Z
+custom:
+    Author: joshuao11
+    Issue: "1389"

--- a/dbt/include/bigquery/macros/materializations/incremental_strategy/merge.sql
+++ b/dbt/include/bigquery/macros/materializations/incremental_strategy/merge.sql
@@ -27,8 +27,12 @@
         {% do predicates.append(avoid_require_partition_filter) %}
     {%- endif -%}
 
-    {% set build_sql = get_merge_sql(target_relation, source_sql, unique_key, dest_columns, predicates) %}
+    -- 1. Run merge statement
+    {{ get_merge_sql(target_relation, source_sql, unique_key, dest_columns, predicates) }};
 
-    {{ return(build_sql) }}
+    {% if tmp_relation_exists -%}
+    -- 2. clean up the temp table if we have used one
+      drop table if exists {{ tmp_relation }};
+    {%- endif -%}
 
 {% endmacro %}


### PR DESCRIPTION
The insert overwrite does this, so let's copy that pattern here to keep the schemas/datasets tidy in BQ for the users

resolves ##[1389](https://github.com/dbt-labs/dbt-adapters/issues/529)

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

When using a `merge` strategy with the model checking the schema (To add or replace columns):
<img width="394" alt="image" src="https://github.com/user-attachments/assets/d50cdbcf-01b3-451e-ab64-2a76dd3e460d">


There is nothing to delete the temp table created:

<img width="1140" alt="image" src="https://github.com/user-attachments/assets/7d54fa71-c1b7-47ef-b77a-212f0ed4cebf">
 

### Solution

We add in a step to delete and tidy up the temporary table, in the same way that is currently there for the `insert_overwrite` strategy:

<img width="1128" alt="image" src="https://github.com/user-attachments/assets/bf4d16f3-5484-4c5a-903a-37f82279049c">

I also checked that there was no impact on the 'ignore' strategy for `on_schema_change`:

There is no temporary table made here so we do not expect the DROP statement to appear:

<img width="1182" alt="image" src="https://github.com/user-attachments/assets/fcdaddeb-7774-45ca-a962-d72e87d3037c">


<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
I ran `tox -p` and everything seems to pass
- [x] This PR includes tests, or tests are not required/relevant for this PR

This change does change a macro but i'm unsure how to get feedback for Product or DX
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
