### PR TITLE
feat(incremental): optimize 'insert_overwrite' strategy (#1409)

### DIFF
--- a/.changes/unreleased/Under the Hood-20241121-191041.yaml
+++ b/.changes/unreleased/Under the Hood-20241121-191041.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: 'refactor(incremental): optimize ''insert_overwrite'' strategy'
+time: 2024-11-21T19:10:41.341213+01:00
+custom:
+    Author: AxelThevenot
+    Issue: "1409"


### PR DESCRIPTION
resolves dbt-labs/dbt-adapters#527 
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) `"N/A"`

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

The `MERGE` statement is sub-optimized in BigQuery when it comes to only replace partitions in the `'insert_overwrite'` strategy for `incremental` models

### Solution

For the `insert_overwrite` strategy where we are looking to replace rows at the partition-level, there is a better solution and here is why:
- a `DELETE` or `INSERT` statement is cheapest than a `MERGE` statement.
- incremental tables are the most expensive tables in real-world projects.
- The `DELETE` statement in BigQuery is [free at the partition-level](https://cloud.google.com/bigquery/docs/managing-partitioned-tables#delete_a_partition).

> This has been tested at Carrefour which is my company. 
- On this replacement of the `MERGE` statement **it reduces the cost by 50.4% and the elapsed time by 35.2%**  (slot based and not on demand)
- On the overall procedure it reduces the cost by 26.1% and the elapsed time by 23.1%

> This is wrapped in a transaction to avoid deleting rows if any error occurs.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR --> (using the same existing tests for `'insert_overwrite'`)
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX