### PR TITLE
feat(incremental): copy multiple tables in parallel (#1237)

### DIFF
--- a/.changes/unreleased/Features-20241126-000241.yaml
+++ b/.changes/unreleased/Features-20241126-000241.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: copy tables and partitions in parallel
+time: 2024-11-26T00:02:41.54479+01:00
+custom:
+    Author: AxelThevenot
+    Issue: "1237"

--- a/dbt/adapters/bigquery/impl.py
+++ b/dbt/adapters/bigquery/impl.py
@@ -409,7 +409,7 @@ class BigQueryAdapter(BaseAdapter):
         return bq_schema
 
     @available.parse(lambda *a, **k: "")
-    def copy_table(self, source, destination, materialization):
+    def copy_table(self, source, destination, materialization, partition_ids=None):
         if materialization == "incremental":
             write_disposition = WRITE_APPEND
         elif materialization == "table":
@@ -421,7 +421,7 @@ class BigQueryAdapter(BaseAdapter):
                 f"{materialization}"
             )
 
-        self.connections.copy_bq_table(source, destination, write_disposition)
+        self.connections.copy_bq_table(source, destination, write_disposition, partition_ids)
 
         return "COPY TABLE with materialization: {}".format(materialization)
 

--- a/dbt/include/bigquery/macros/materializations/incremental_strategy/insert_overwrite.sql
+++ b/dbt/include/bigquery/macros/materializations/incremental_strategy/insert_overwrite.sql
@@ -18,22 +18,26 @@
 
 {% macro bq_copy_partitions(tmp_relation, target_relation, partitions, partition_by) %}
 
+  {% set partition_ids = [] %}
+
   {% for partition in partitions %}
     {% if partition_by.data_type == 'int64' %}
       {% set partition = partition | as_text %}
     {% elif partition_by.granularity == 'hour' %}
-      {% set partition = partition.strftime("%Y%m%d%H") %}
+      {% set partition = partition.strftime('%Y%m%d%H') %}
     {% elif partition_by.granularity == 'day' %}
-      {% set partition = partition.strftime("%Y%m%d") %}
+      {% set partition = partition.strftime('%Y%m%d') %}
     {% elif partition_by.granularity == 'month' %}
-      {% set partition = partition.strftime("%Y%m") %}
+      {% set partition = partition.strftime('%Y%m') %}
     {% elif partition_by.granularity == 'year' %}
-      {% set partition = partition.strftime("%Y") %}
+      {% set partition = partition.strftime('%Y') %}
     {% endif %}
-    {% set tmp_relation_partitioned = api.Relation.create(database=tmp_relation.database, schema=tmp_relation.schema, identifier=tmp_relation.table ~ '$' ~ partition, type=tmp_relation.type) %}
-    {% set target_relation_partitioned = api.Relation.create(database=target_relation.database, schema=target_relation.schema, identifier=target_relation.table ~ '$' ~ partition, type=target_relation.type) %}
-    {% do adapter.copy_table(tmp_relation_partitioned, target_relation_partitioned, "table") %}
+
+    {% do partition_ids.append(partition) %}
+
   {% endfor %}
+
+  {% do adapter.copy_table(tmp_relation, target_relation, 'table', partition_ids) %}
 
 {% endmacro %}
 


### PR DESCRIPTION
resolves dbt-labs/dbt-adapters#559 
[N/A](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

Copy partitions and tables in parallel instead of sequentially which is slow for large partition management

### Solution

Run jobs in parallel and waits for the results.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
