### PR TITLE
[Feature] Allow `copy_partitions` when using `microbatch`

### DIFF
--- a/.changes/unreleased/Features-20241202-223835.yaml
+++ b/.changes/unreleased/Features-20241202-223835.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Allow copy_partitions in microbatch
+time: 2024-12-02T22:38:35.479052Z
+custom:
+    Author: borjavb
+    Issue: "1414"

--- a/dbt/include/bigquery/macros/materializations/incremental.sql
+++ b/dbt/include/bigquery/macros/materializations/incremental.sql
@@ -95,9 +95,9 @@
 
   {{ run_hooks(pre_hooks) }}
 
-  {% if partition_by.copy_partitions is true and strategy != 'insert_overwrite' %} {#-- We can't copy partitions with merge strategy --#}
+  {% if partition_by.copy_partitions is true and strategy not in ['insert_overwrite', 'microbatch'] %} {#-- We can't copy partitions with merge strategy --#}
         {% set wrong_strategy_msg -%}
-        The 'copy_partitions' option requires the 'incremental_strategy' option to be set to 'insert_overwrite'.
+        The 'copy_partitions' option requires the 'incremental_strategy' option to be set to 'insert_overwrite' or 'microbatch'.
         {%- endset %}
         {% do exceptions.raise_compiler_error(wrong_strategy_msg) %}
 

--- a/tests/functional/adapter/incremental/incremental_strategy_fixtures.py
+++ b/tests/functional/adapter/incremental/incremental_strategy_fixtures.py
@@ -611,3 +611,21 @@ microbatch_model_invalid_partition_by_sql = """
 }}
 select * from {{ ref('input_model') }}
 """
+
+microbatch_model_no_unique_id_copy_partitions_sql = """
+{{ config(
+    materialized='incremental',
+    incremental_strategy='microbatch',
+    partition_by={
+      'field': 'event_time',
+      'data_type': 'timestamp',
+      'granularity': 'day',
+      'copy_partitions': true
+    },
+    event_time='event_time',
+    batch_size='day',
+    begin=modules.datetime.datetime(2020, 1, 1, 0, 0, 0)
+    )
+}}
+select * from {{ ref('input_model') }}
+"""

--- a/tests/functional/adapter/incremental/test_incremental_microbatch.py
+++ b/tests/functional/adapter/incremental/test_incremental_microbatch.py
@@ -85,4 +85,4 @@ class TestBigQueryMicrobatchInvalidPartitionByGranularity:
 class TestBigQueryMicrobatchWithCopyPartitions(BaseMicrobatch):
     @pytest.fixture(scope="class")
     def microbatch_model_sql(self) -> str:
-        return microbatch_model_invalid_partition_by_sql
+        return microbatch_model_no_unique_id_copy_partitions_sql

--- a/tests/functional/adapter/incremental/test_incremental_microbatch.py
+++ b/tests/functional/adapter/incremental/test_incremental_microbatch.py
@@ -81,6 +81,7 @@ class TestBigQueryMicrobatchInvalidPartitionByGranularity:
             in stdout
         )
 
+
 class TestBigQueryMicrobatchWithCopyPartitions(BaseMicrobatch):
     @pytest.fixture(scope="class")
     def microbatch_model_sql(self) -> str:

--- a/tests/functional/adapter/incremental/test_incremental_microbatch.py
+++ b/tests/functional/adapter/incremental/test_incremental_microbatch.py
@@ -13,6 +13,7 @@ from tests.functional.adapter.incremental.incremental_strategy_fixtures import (
     microbatch_input_sql,
     microbatch_model_no_partition_by_sql,
     microbatch_model_invalid_partition_by_sql,
+    microbatch_model_no_unique_id_copy_partitions_sql,
 )
 
 
@@ -53,3 +54,8 @@ class TestBigQueryMicrobatchInvalidPartitionByGranularity:
             "The 'microbatch' strategy requires a `partition_by` config with the same granularity as its configured `batch_size`"
             in stdout
         )
+
+class TestBigQueryMicrobatchWithCopyPartitions(BaseMicrobatch):
+    @pytest.fixture(scope="class")
+    def microbatch_model_sql(self) -> str:
+        return microbatch_model_invalid_partition_by_sql


### PR DESCRIPTION
resolves #
https://github.com/dbt-labs/dbt-bigquery/issues/1414
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem
`copy_partitions` was only being allowed for insert_overwrite, but it makes sense to allowlist it when using `microbatch` too.
<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

Allowlist `copy_partitions` as part of `microbatch` too.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
