### PR TITLE
Fix: Cast to timestamp prior to event time comparison

### DIFF
--- a/.changes/unreleased/Fixes-20241204-105846.yaml
+++ b/.changes/unreleased/Fixes-20241204-105846.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Cast `event_time` to a timestamp prior to comparing against microbatch start/end
+  time
+time: 2024-12-04T10:58:46.573608-05:00
+custom:
+  Author: michelleark
+  Issue: "1422"

--- a/dbt/adapters/bigquery/relation.py
+++ b/dbt/adapters/bigquery/relation.py
@@ -4,7 +4,12 @@ from typing import FrozenSet, Optional, TypeVar
 
 from dbt_common.exceptions import CompilationError
 from dbt_common.utils.dict import filter_null_values
-from dbt.adapters.base.relation import BaseRelation, ComponentName, InformationSchema
+from dbt.adapters.base.relation import (
+    BaseRelation,
+    ComponentName,
+    InformationSchema,
+    EventTimeFilter,
+)
 from dbt.adapters.contracts.relation import RelationConfig, RelationType
 from dbt.adapters.relation_configs import RelationConfigChangeAction
 
@@ -115,6 +120,24 @@ class BigQueryRelation(BaseRelation):
 
     def information_schema(self, identifier: Optional[str] = None) -> "BigQueryInformationSchema":
         return BigQueryInformationSchema.from_relation(self, identifier)
+
+    def _render_event_time_filtered(self, event_time_filter: EventTimeFilter) -> str:
+        """
+        Returns "" if start and end are both None
+        """
+        filter = ""
+        if event_time_filter.start and event_time_filter.end:
+            filter = f"cast({event_time_filter.field_name} as timestamp) >= '{event_time_filter.start}' and cast({event_time_filter.field_name} as timestamp) < '{event_time_filter.end}'"
+        elif event_time_filter.start:
+            filter = (
+                f"cast({event_time_filter.field_name} as timestamp) >= '{event_time_filter.start}'"
+            )
+        elif event_time_filter.end:
+            filter = (
+                f"cast({event_time_filter.field_name} as timestamp) < '{event_time_filter.end}'"
+            )
+
+        return filter
 
 
 @dataclass(frozen=True, eq=False, repr=False)

--- a/tests/functional/adapter/incremental/incremental_strategy_fixtures.py
+++ b/tests/functional/adapter/incremental/incremental_strategy_fixtures.py
@@ -570,7 +570,7 @@ microbatch_model_no_unique_id_sql = """
     begin=modules.datetime.datetime(2020, 1, 1, 0, 0, 0)
     )
 }}
-select * from {{ ref('input_model') }}
+select id, cast(event_time as timestamp) as event_time from {{ ref('input_model') }}
 """
 
 microbatch_input_sql = """
@@ -580,6 +580,24 @@ union all
 select 2 as id, TIMESTAMP '2020-01-02 00:00:00-0' as event_time
 union all
 select 3 as id, TIMESTAMP '2020-01-03 00:00:00-0' as event_time
+"""
+
+microbatch_input_event_time_date_sql = """
+{{ config(materialized='table', event_time='event_time') }}
+select 1 as id, DATE '2020-01-01' as event_time
+union all
+select 2 as id, DATE '2020-01-02' as event_time
+union all
+select 3 as id, DATE '2020-01-03' as event_time
+"""
+
+microbatch_input_event_time_datetime_sql = """
+{{ config(materialized='table', event_time='event_time') }}
+select 1 as id, DATETIME '2020-01-01' as event_time
+union all
+select 2 as id, DATETIME '2020-01-02' as event_time
+union all
+select 3 as id, DATETIME '2020-01-03' as event_time
 """
 
 microbatch_model_no_partition_by_sql = """

--- a/tests/functional/adapter/incremental/test_incremental_microbatch.py
+++ b/tests/functional/adapter/incremental/test_incremental_microbatch.py
@@ -13,6 +13,8 @@ from tests.functional.adapter.incremental.incremental_strategy_fixtures import (
     microbatch_input_sql,
     microbatch_model_no_partition_by_sql,
     microbatch_model_invalid_partition_by_sql,
+    microbatch_input_event_time_date_sql,
+    microbatch_input_event_time_datetime_sql,
 )
 
 
@@ -20,6 +22,32 @@ class TestBigQueryMicrobatch(BaseMicrobatch):
     @pytest.fixture(scope="class")
     def microbatch_model_sql(self) -> str:
         return microbatch_model_no_unique_id_sql
+
+
+class TestBigQueryMicrobatchInputWithDate(TestBigQueryMicrobatch):
+    @pytest.fixture(scope="class")
+    def input_model_sql(self) -> str:
+        return microbatch_input_event_time_date_sql
+
+    @pytest.fixture(scope="class")
+    def insert_two_rows_sql(self, project) -> str:
+        test_schema_relation = project.adapter.Relation.create(
+            database=project.database, schema=project.test_schema
+        )
+        return f"insert into {test_schema_relation}.input_model (id, event_time) values (4, DATE '2020-01-04'), (5, DATE '2020-01-05')"
+
+
+class TestBigQueryMicrobatchInputWithDatetime(TestBigQueryMicrobatch):
+    @pytest.fixture(scope="class")
+    def input_model_sql(self) -> str:
+        return microbatch_input_event_time_datetime_sql
+
+    @pytest.fixture(scope="class")
+    def insert_two_rows_sql(self, project) -> str:
+        test_schema_relation = project.adapter.Relation.create(
+            database=project.database, schema=project.test_schema
+        )
+        return f"insert into {test_schema_relation}.input_model (id, event_time) values (4, DATETIME '2020-01-04'), (5, DATETIME '2020-01-05')"
 
 
 class TestBigQueryMicrobatchMissingPartitionBy:
@@ -30,7 +58,6 @@ class TestBigQueryMicrobatchMissingPartitionBy:
             "input_model.sql": microbatch_input_sql,
         }
 
-    @mock.patch.dict(os.environ, {"DBT_EXPERIMENTAL_MICROBATCH": "True"})
     def test_execution_failure_no_partition_by(self, project):
         with patch_microbatch_end_time("2020-01-03 13:57:00"):
             _, stdout = run_dbt_and_capture(["run"], expect_pass=False)
@@ -45,7 +72,6 @@ class TestBigQueryMicrobatchInvalidPartitionByGranularity:
             "input_model.sql": microbatch_input_sql,
         }
 
-    @mock.patch.dict(os.environ, {"DBT_EXPERIMENTAL_MICROBATCH": "True"})
     def test_execution_failure_no_partition_by(self, project):
         with patch_microbatch_end_time("2020-01-03 13:57:00"):
             _, stdout = run_dbt_and_capture(["run"], expect_pass=False)


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-bigquery/issues/1412
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->
It's not currently possible to use microbatch models with inputs that aren't of type `timestamp`, because BigQuery does not coerce dates or datetimes to timestamps automatically when compared to literal timestamps. 

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

Cast `event_time` to timestamp on rendering, prior to comparing against timestamp literal.

https://cloud.google.com/bigquery/docs/reference/standard-sql/conversion_functions#cast_as_timestamp
works for inputs of type: 
* string
* date - assumes midnight UTC
* datetime - assumes UTC
* timestamp 

(shoutout to @jtcohen6 for helping with this solutioning)

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
