### PR TITLE
Remove custom retry in get_table call

### DIFF
--- a/.changes/unreleased/Fixes-20241205-133606.yaml
+++ b/.changes/unreleased/Fixes-20241205-133606.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix issue where rate limit errors on table service calls are not retried
+time: 2024-12-05T13:36:06.436005-05:00
+custom:
+  Author: mikealfare
+  Issue: "1423"

--- a/dbt/adapters/bigquery/connections.py
+++ b/dbt/adapters/bigquery/connections.py
@@ -519,10 +519,7 @@ class BigQueryConnectionManager(BaseConnectionManager):
         # backwards compatibility: fill in with defaults if not specified
         database = database or conn.credentials.database
         schema = schema or conn.credentials.schema
-        return client.get_table(
-            table=self.table_ref(database, schema, identifier),
-            retry=self._retry.create_reopen_with_deadline(conn),
-        )
+        return client.get_table(self.table_ref(database, schema, identifier))
 
     def drop_dataset(self, database, schema) -> None:
         conn = self.get_thread_connection()


### PR DESCRIPTION
resolves #

### Problem

We added a custom retry predicate in a call to `get_table` when adding the retry factory and it appears to be missing some retryable errors (versus the default).

### Solution

Remove the custom retry and use the built in default.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX