### PR TITLE
Display Job URL at Info Log Level

### DIFF
--- a/.changes/unreleased/Features-20241210-175614.yaml
+++ b/.changes/unreleased/Features-20241210-175614.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Display Job URL at Info Log Level
+time: 2024-12-10T17:56:14.943063-08:00
+custom:
+    Author: thatInfrastructureGuy
+    Issue: "696"

--- a/dbt/adapters/bigquery/connections.py
+++ b/dbt/adapters/bigquery/connections.py
@@ -578,9 +578,7 @@ class BigQueryConnectionManager(BaseConnectionManager):
             and query_job.job_id is not None
             and query_job.project is not None
         ):
-            logger.debug(
-                self._bq_job_link(query_job.location, query_job.project, query_job.job_id)
-            )
+            logger.info(self._bq_job_link(query_job.location, query_job.project, query_job.job_id))
 
         timeout = self._retry.create_job_execution_timeout()
         try:


### PR DESCRIPTION
Original Discussion at https://github.com/dbt-labs/dbt-bigquery/pull/697/files#r1212630246

> Job URL is super useful even beyond debugging code, since it's the ground truth of what logic and process is actually executing the model

resolves #696

### Problem

BigQuery Job URL is hidden in debug logs. This makes it difficult to debug.

### Solution

Display Job URL as part of Info logs

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
