### PR TITLE
[Bug] Use bigquery default retryable exceptions

### DIFF
--- a/.changes/unreleased/Fixes-20241211-144752.yaml
+++ b/.changes/unreleased/Fixes-20241211-144752.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix retry scenarios so that dbt always retries when BigQuery recommends a retry
+time: 2024-12-11T14:47:52.36905-05:00
+custom:
+  Author: mikealfare
+  Issue: "263"

--- a/dbt/adapters/bigquery/retry.py
+++ b/dbt/adapters/bigquery/retry.py
@@ -1,6 +1,5 @@
 from typing import Callable, Optional
 
-from google.api_core.exceptions import Forbidden
 from google.api_core.future.polling import DEFAULT_POLLING
 from google.api_core.retry import Retry
 from google.cloud.bigquery.retry import DEFAULT_RETRY, _job_should_retry

--- a/dbt/adapters/bigquery/retry.py
+++ b/dbt/adapters/bigquery/retry.py
@@ -3,7 +3,6 @@ from typing import Callable, Optional
 from google.api_core.future.polling import DEFAULT_POLLING
 from google.api_core.retry import Retry
 from google.cloud.bigquery.retry import DEFAULT_RETRY, _job_should_retry
-from google.cloud.exceptions import BadRequest
 from requests.exceptions import ConnectionError
 
 from dbt.adapters.contracts.connection import Connection, ConnectionState
@@ -73,10 +72,6 @@ class _DeferredException:
         self._retries: int = retries
         self._error_count = 0
 
-    @staticmethod
-    def _is_retryable(error: Exception) -> bool:
-        """Return true for errors that are unlikely to occur again if retried."""
-        return _job_should_retry(error) or isinstance(error, BadRequest)
 
     def __call__(self, error: Exception) -> bool:
         # exit immediately if the user does not want retries
@@ -87,7 +82,7 @@ class _DeferredException:
         self._error_count += 1
 
         # if the error is retryable, and we haven't breached the threshold, log and continue
-        if self._is_retryable(error) and self._error_count <= self._retries:
+        if _job_should_retry(error) and self._error_count <= self._retries:
             _logger.debug(
                 f"Retry attempt {self._error_count} of {self._retries} after error: {repr(error)}"
             )

--- a/dbt/adapters/bigquery/retry.py
+++ b/dbt/adapters/bigquery/retry.py
@@ -72,7 +72,6 @@ class _DeferredException:
         self._retries: int = retries
         self._error_count = 0
 
-
     def __call__(self, error: Exception) -> bool:
         # exit immediately if the user does not want retries
         if self._retries == 0:

--- a/tests/unit/test_bigquery_connection_manager.py
+++ b/tests/unit/test_bigquery_connection_manager.py
@@ -53,7 +53,7 @@ class TestBigQueryConnectionManager(unittest.TestCase):
         assert new_mock_client is not self.mock_client
 
     def test_is_retryable(self):
-        _is_retryable = dbt.adapters.bigquery.retry._DeferredException(1)._is_retryable
+        _is_retryable = google.cloud.bigquery.retry._job_should_retry
         exceptions = dbt.adapters.bigquery.impl.google.cloud.exceptions
         internal_server_error = exceptions.InternalServerError("code broke")
         bad_request_error = exceptions.BadRequest("code broke")
@@ -65,7 +65,7 @@ class TestBigQueryConnectionManager(unittest.TestCase):
         service_unavailable_error = exceptions.ServiceUnavailable("service is unavailable")
 
         self.assertTrue(_is_retryable(internal_server_error))
-        self.assertTrue(_is_retryable(bad_request_error))
+        self.assertFalse(_is_retryable(bad_request_error))  # this was removed after initially being included
         self.assertTrue(_is_retryable(connection_error))
         self.assertFalse(_is_retryable(client_error))
         self.assertTrue(_is_retryable(rate_limit_error))

--- a/tests/unit/test_bigquery_connection_manager.py
+++ b/tests/unit/test_bigquery_connection_manager.py
@@ -53,7 +53,7 @@ class TestBigQueryConnectionManager(unittest.TestCase):
         assert new_mock_client is not self.mock_client
 
     def test_is_retryable(self):
-        _is_retryable = dbt.adapters.bigquery.retry._is_retryable
+        _is_retryable = dbt.adapters.bigquery.retry._DeferredException(1)._is_retryable
         exceptions = dbt.adapters.bigquery.impl.google.cloud.exceptions
         internal_server_error = exceptions.InternalServerError("code broke")
         bad_request_error = exceptions.BadRequest("code broke")

--- a/tests/unit/test_bigquery_connection_manager.py
+++ b/tests/unit/test_bigquery_connection_manager.py
@@ -65,7 +65,9 @@ class TestBigQueryConnectionManager(unittest.TestCase):
         service_unavailable_error = exceptions.ServiceUnavailable("service is unavailable")
 
         self.assertTrue(_is_retryable(internal_server_error))
-        self.assertFalse(_is_retryable(bad_request_error))  # this was removed after initially being included
+        self.assertFalse(
+            _is_retryable(bad_request_error)
+        )  # this was removed after initially being included
         self.assertTrue(_is_retryable(connection_error))
         self.assertFalse(_is_retryable(client_error))
         self.assertTrue(_is_retryable(rate_limit_error))


### PR DESCRIPTION
resolves #263

### Problem

We're not retrying in all scenarios that BigQuery recommends. This is causing unexpected behavior for users. This likely happened as a result of us maintaining our own list of retryable errors, which fell out of sync with BigQuery's development over time.

### Solution

Instead of maintaining our own list, we should rely on BigQuery's list of retryable errors and reasons. However, we have one scenario that is not covered by BigQuery's defaults, `BadRequest`. We need to also check this scenario after checking BigQuery's defaults to maintain backwards compatibility.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX