### PR TITLE
Update the pytest timeout from 10min to 15min for python tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ passenv =
     DD_ENV
     DD_SERVICE
 commands =
-  {envpython} -m pytest {posargs} --timeout 600  -vv tests/functional -k "TestPython" --profile service_account
+  {envpython} -m pytest {posargs} --timeout 900  -vv tests/functional -k "TestPython" --profile service_account
 deps =
   -rdev-requirements.txt
   -e.


### PR DESCRIPTION
### Problem

One of the python model tests takes just over 10 minutes to complete when run locally. However, we specify a timeout of 10 minutes in `tox.ini`.

### Solution

Bump the timeout from 10 minutes to 15 minutes to allow the test to complete. This doesn't appear to be an issue in newer versions of `dbt-bigquery`, so it's not necessary to apply this change to newer versions.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
