### PR TITLE
Update the default inputs on the integration tests workflow to match the branch

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -46,7 +46,7 @@ on:
         description: "The branch of this adapter repository to use"
         type: string
         required: false
-        default: "main"
+        default: "1.9.latest"
       dbt_adapters_branch:
         description: "The branch of dbt-adapters to use"
         type: string
@@ -56,7 +56,7 @@ on:
         description: "The branch of dbt-core to use"
         type: string
         required: false
-        default: "main"
+        default: "1.9.latest"
       dbt_common_branch:
         description: "The branch of dbt-common to use"
         type: string


### PR DESCRIPTION
### Problem

We're defaulting to `main` in integration tests for the adapter and core branches. The scheduled release branch tests don't pass inputs, so they check out 1.9.latest and then that workflow in turn checks out the default, `main`. This does not affect prior release branches since the functionality to select a branch was introduced after we cut the `1.8.latest` branch.

### Solution

- update the defaults for `dbt-core` and `dbt-bigquery` to be `1.9.latest`
- handle future release branch tests in the monorepo

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX