### PR TITLE
Combine build verification jobs to avoid needing to upload and download artifacts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,24 +110,25 @@ jobs:
           path: unit_results.csv
           overwrite: true
 
-  build:
-    name: build packages
-
-    runs-on: ubuntu-latest
-
-    outputs:
-      is_alpha: ${{ steps.check-is-alpha.outputs.is_alpha }}
-
+  test-build:
+    name: verify packages / python ${{ matrix.python-version }} / ${{ matrix.os }} / ${{ matrix.dist-type }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-14, windows-latest]
+        python-version: ['3.9', '3.10', '3.11', '3.12']
+        dist-type: ["whl", "gz"]
     steps:
       - name: Check out the repository
         uses: actions/checkout@v4
         with:
           persist-credentials: false
 
-      - name: Set up Python
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: ${{ matrix.python-version }}
 
       - name: Install python dependencies
         run: |
@@ -142,12 +143,10 @@ jobs:
         run: ls -lh dist/
 
       - name: Check distribution descriptions
-        run: |
-          twine check dist/*
+        run: twine check dist/*
 
       - name: Check wheel contents
-        run: |
-          check-wheel-contents dist/*.whl --ignore W007,W008
+        run: check-wheel-contents dist/*.whl --ignore W007,W008
 
       - name: Check if this is an alpha version
         id: check-is-alpha
@@ -156,52 +155,10 @@ jobs:
           if [[ "$(ls -lh dist/)" == *"a1"* ]]; then export is_alpha=1; fi
           echo "is_alpha=$is_alpha" >> $GITHUB_OUTPUT
 
-      - uses: actions/upload-artifact@v4
-        with:
-          name: dist
-          path: dist/
-          overwrite: true
-
-  test-build:
-    name: verify packages / python ${{ matrix.python-version }} / ${{ matrix.os }} / ${{ matrix.dist-type }}
-
-    if: needs.build.outputs.is_alpha == 0
-
-    needs: build
-
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-14, windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
-        dist-type: ["whl", "gz"]
-
-    steps:
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install python dependencies
-        run: |
-          python -m pip install --user --upgrade pip
-          python -m pip install --upgrade wheel
-          python -m pip --version
-
-      - uses: actions/download-artifact@v4
-        with:
-          name: dist
-          path: dist/
-
-      - name: Show distributions
-        run: ls -lh dist/
-
       - name: Install ${{ matrix.dist-type }} distributions
-        run: |
-          find ./dist/*.${{ matrix.dist-type }} -maxdepth 1 -type f | xargs python -m pip install --force-reinstall --find-links=dist/
+        if: ${{ steps.check-is-alpha.outputs.is_alpha == 0 }}
+        run: find ./dist/*.${{ matrix.dist-type }} -maxdepth 1 -type f | xargs python -m pip install --force-reinstall --find-links=dist/
 
       - name: Check ${{ matrix.dist-type }} distributions
-        run: |
-          python -c "import dbt.adapters.bigquery"
+        if: ${{ steps.check-is-alpha.outputs.is_alpha == 0 }}
+        run: python -c "import dbt.adapters.bigquery"


### PR DESCRIPTION
The build verification check is broken. We only build one artifact, py39 on ubuntu, but then we download it several times and check it under the premise that we're checking various Python versions and OS's. Additionally, we broke prior build verification checks by removing the upload and download steps that happen between these jobs.

We should instead run the two jobs as one single job and apply the matrix to the whole job. This will correctly test each build scenario and avoid the need for uploading and downloading artifacts.