### PR TITLE
Enable authorization of materialized views

### DIFF
--- a/.changes/unreleased/Fixes-20250202-105422.yaml
+++ b/.changes/unreleased/Fixes-20250202-105422.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix silently ignoring materialized view authorization
+time: 2025-02-02T10:54:22.12198+01:00
+custom:
+  Author: kubikb
+  Issue: "1471"

--- a/dbt/include/bigquery/macros/materializations/table.sql
+++ b/dbt/include/bigquery/macros/materializations/table.sql
@@ -41,6 +41,12 @@
 
   {% do persist_docs(target_relation, model) %}
 
+  {% if config.get('materialized') == "materialized_view" and config.get('grant_access_to') %}
+    {% for grant_target_dict in config.get('grant_access_to') %}
+      {% do adapter.grant_access_to(this, 'view', None, grant_target_dict) %}
+    {% endfor %}
+  {% endif %}
+
   {{ return({'relations': [target_relation]}) }}
 
 {% endmaterialization %}

--- a/dbt/include/bigquery/macros/materializations/table.sql
+++ b/dbt/include/bigquery/macros/materializations/table.sql
@@ -41,12 +41,6 @@
 
   {% do persist_docs(target_relation, model) %}
 
-  {% if config.get('materialized') == "materialized_view" and config.get('grant_access_to') %}
-    {% for grant_target_dict in config.get('grant_access_to') %}
-      {% do adapter.grant_access_to(this, 'view', None, grant_target_dict) %}
-    {% endfor %}
-  {% endif %}
-
   {{ return({'relations': [target_relation]}) }}
 
 {% endmaterialization %}

--- a/dbt/include/bigquery/macros/relations/materialized_view/create.sql
+++ b/dbt/include/bigquery/macros/relations/materialized_view/create.sql
@@ -2,6 +2,12 @@
 
     {%- set materialized_view = adapter.Relation.materialized_view_from_relation_config(config.model) -%}
 
+    {% if config.get('grant_access_to') %}
+      {% for grant_target_dict in config.get('grant_access_to') %}
+        {% do adapter.grant_access_to(this, 'view', None, grant_target_dict) %}
+      {% endfor %}
+    {% endif %}
+
     create materialized view if not exists {{ relation }}
     {% if materialized_view.partition %}{{ partition_by(materialized_view.partition) }}{% endif %}
     {% if materialized_view.cluster %}{{ cluster_by(materialized_view.cluster.fields) }}{% endif %}

--- a/dbt/include/bigquery/macros/relations/materialized_view/replace.sql
+++ b/dbt/include/bigquery/macros/relations/materialized_view/replace.sql
@@ -2,6 +2,12 @@
 
     {%- set materialized_view = adapter.Relation.materialized_view_from_relation_config(config.model) -%}
 
+    {% if config.get('grant_access_to') %}
+      {% for grant_target_dict in config.get('grant_access_to') %}
+        {% do adapter.grant_access_to(this, 'view', None, grant_target_dict) %}
+      {% endfor %}
+    {% endif %}
+
     create or replace materialized view if not exists {{ relation }}
     {% if materialized_view.partition %}{{ partition_by(materialized_view.partition) }}{% endif %}
     {% if materialized_view.cluster %}{{ cluster_by(materialized_view.cluster.fields) }}{% endif %}

--- a/tests/functional/adapter/test_grant_access_to.py
+++ b/tests/functional/adapter/test_grant_access_to.py
@@ -104,7 +104,6 @@ class TestAccessGrantSucceeds:
         # Materialized view excluded since it would produce an error since source table is replaced
         results = run_dbt(["run", "--exclude", "select_1_materialized_view"])
         assert len(results) == 2
-        time.sleep(3)
 
         with project.adapter.connection_named("__test_grants"):
             client = project.adapter.connections.get_thread_connection().handle

--- a/tests/functional/adapter/test_grant_access_to.py
+++ b/tests/functional/adapter/test_grant_access_to.py
@@ -101,8 +101,9 @@ class TestAccessGrantSucceeds:
         results = run_dbt(["run"])
         assert len(results) == 3
         time.sleep(10)
-        results = run_dbt(["run"])
-        assert len(results) == 3
+        # Materialized view excluded since it would produce an error since source table is replaced
+        results = run_dbt(["run", "--exclude", "select_1_materialized_view"])
+        assert len(results) == 2
         time.sleep(3)
 
         with project.adapter.connection_named("__test_grants"):


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-adapters/issues/773.

### Problem
Similarly to BigQuery views, [BigQuery materialized views can also be authorized to access the data in another dataset(s)](https://cloud.google.com/bigquery/docs/authorized-views). However, providing the `grant_access_to` configuration to a model with `materialized_view` materialization goes silently ignored and the materialized view does NOT get authorized to access data in another dataset. With models with `view` materialization, the `grant_access_to` configuration leads to the desired behavior, namely the view gets authorized to access data in another dataset.

### Solution
This pull request add logic to handle the config `grant_access_to` also for models with materialization `materialized_view`. The PR also extends currently existing tests.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
